### PR TITLE
Add idle animations to mirroring

### DIFF
--- a/Console/Mirror/MirrorCommand.cs
+++ b/Console/Mirror/MirrorCommand.cs
@@ -28,6 +28,7 @@ namespace DmdExt.Mirror
 				Resize = _options.Resize,
 				FlipHorizontally = _options.FlipHorizontally,
 				FlipVertically = _options.FlipVertically,
+				IdleDuration = _options.IdleDuration
 			};
 			_graph.SetColor(ColorUtil.ParseColor(_options.RenderColor));
 

--- a/Console/Mirror/MirrorCommand.cs
+++ b/Console/Mirror/MirrorCommand.cs
@@ -28,7 +28,8 @@ namespace DmdExt.Mirror
 				Resize = _options.Resize,
 				FlipHorizontally = _options.FlipHorizontally,
 				FlipVertically = _options.FlipVertically,
-				IdleAfter = _options.IdleAfter
+				IdleAfter = _options.IdleAfter,
+				IdlePlay = _options.IdlePlay
 			};
 			_graph.SetColor(ColorUtil.ParseColor(_options.RenderColor));
 

--- a/Console/Mirror/MirrorCommand.cs
+++ b/Console/Mirror/MirrorCommand.cs
@@ -28,7 +28,7 @@ namespace DmdExt.Mirror
 				Resize = _options.Resize,
 				FlipHorizontally = _options.FlipHorizontally,
 				FlipVertically = _options.FlipVertically,
-				IdleDuration = _options.IdleDuration
+				IdleAfter = _options.IdleAfter
 			};
 			_graph.SetColor(ColorUtil.ParseColor(_options.RenderColor));
 

--- a/Console/Mirror/MirrorOptions.cs
+++ b/Console/Mirror/MirrorOptions.cs
@@ -18,6 +18,9 @@ namespace DmdExt.Mirror
 		[Option('f', "fps", HelpText = "How many frames per second should be mirrored. Default: 25")]
 		public double FramesPerSecond { get; set; } = 25d;
 
+		[Option("idle-duration", HelpText = "Wait for number of milliseconds until clearing the screen. Disable with 0. Default: 0.")]
+		public int IdleDuration { get; set; } = 0;
+
 		[OptionArray("position", HelpText = "[screen] Position and size of screen grabber source. Four values: <Left> <Top> <Width> <Height>. Default: \"0 0 128 32\".")]
 		public int[] Position { get; set; } = { 0, 0, 128, 32 };
 

--- a/Console/Mirror/MirrorOptions.cs
+++ b/Console/Mirror/MirrorOptions.cs
@@ -18,8 +18,8 @@ namespace DmdExt.Mirror
 		[Option('f', "fps", HelpText = "How many frames per second should be mirrored. Default: 25")]
 		public double FramesPerSecond { get; set; } = 25d;
 
-		[Option("idle-duration", HelpText = "Wait for number of milliseconds until clearing the screen. Disable with 0. Default: 0.")]
-		public int IdleDuration { get; set; } = 0;
+		[Option("idle-after", HelpText = "Wait for number of milliseconds until clearing the screen. Disable with 0. Default: 0.")]
+		public int IdleAfter { get; set; } = 0;
 
 		[OptionArray("position", HelpText = "[screen] Position and size of screen grabber source. Four values: <Left> <Top> <Width> <Height>. Default: \"0 0 128 32\".")]
 		public int[] Position { get; set; } = { 0, 0, 128, 32 };

--- a/Console/Mirror/MirrorOptions.cs
+++ b/Console/Mirror/MirrorOptions.cs
@@ -21,6 +21,9 @@ namespace DmdExt.Mirror
 		[Option("idle-after", HelpText = "Wait for number of milliseconds until clearing the screen. Disable with 0. Default: 0.")]
 		public int IdleAfter { get; set; } = 0;
 
+		[Option("idle-play", HelpText = "Play this file while idleing instead of blank screen. Supported formats: JPG, PNG, GIF. Animated GIFs are supported.")]
+		public string IdlePlay { get; set; }
+
 		[OptionArray("position", HelpText = "[screen] Position and size of screen grabber source. Four values: <Left> <Top> <Width> <Height>. Default: \"0 0 128 32\".")]
 		public int[] Position { get; set; } = { 0, 0, 128, 32 };
 

--- a/LibDmd/Common/FrameUtil.cs
+++ b/LibDmd/Common/FrameUtil.cs
@@ -1,15 +1,17 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Drawing.Imaging;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using NLog;
 using NLog.Fluent;
+using Color = System.Windows.Media.Color;
 
 namespace LibDmd.Common
 {

--- a/LibDmd/Input/ISource.cs
+++ b/LibDmd/Input/ISource.cs
@@ -1,23 +1,21 @@
 ﻿using System;
 using System.Reactive;
 using System.Reactive.Subjects;
-using System.Security.RightsManagement;
-using System.Windows.Media.Imaging;
-using LibDmd.Output;
 
 namespace LibDmd.Input
 {
 	/// <summary>
 	/// Acts as source for any frames ending up on the DMD.
 	/// </summary>
+	/// 
 	/// <remarks>
 	/// Since we want a contineous flow of frames, the method to override
 	/// returns an observable. Note that the producer decides on the frequency
 	/// in which frames are delivered to the consumer.
 	/// 
 	/// When implementing a source, make sure to only implement the "native"
-	/// bit lengths of the source. Convertion if necessary is done in the render
-	/// graph directly.
+	/// bit lengths of the source. Convertion if necessary is done in the Render
+	/// Graph directly.
 	/// </remarks>
 	public interface ISource
 	{
@@ -42,6 +40,9 @@ namespace LibDmd.Input
 		IObservable<Unit> OnPause { get; }
 	}
 
+	/// <summary>
+	/// A set of dimensions, in pixel.
+	/// </summary>
 	public struct Dimensions
 	{
 		public int Width { get; set; }

--- a/LibDmd/Output/Virtual/VirtualDmdControl.xaml.cs
+++ b/LibDmd/Output/Virtual/VirtualDmdControl.xaml.cs
@@ -19,7 +19,7 @@ namespace LibDmd.Output.Virtual
 	// pindmd3: IGray2Destination, IGray4Destination, IColoredGray2Destination, IFixedSizeDestination
 	{
 		public int DmdWidth { get; private set; } = 128;
-		public int DmdHeight { get;private set; } = 32;
+		public int DmdHeight { get; private set; } = 32;
 
 		public bool IsAvailable { get; } = true;
 
@@ -137,7 +137,7 @@ namespace LibDmd.Output.Virtual
 
 		public void ClearDisplay()
 		{
-			// nothing to clear
+			RenderGray4(new byte[DmdWidth * DmdHeight]);
 		}
 
 		public void Dispose()

--- a/LibDmd/RenderGraph.cs
+++ b/LibDmd/RenderGraph.cs
@@ -89,7 +89,7 @@ namespace LibDmd
 		/// <summary>
 		/// If >0, add a timer to each pipeline that clears the screen after n milliseconds.
 		/// </summary>
-		public int IdleDuration { get; set; } = 0;
+		public int IdleAfter { get; set; } = 0;
 
 		/// <summary>
 		/// The default color used if there are no palette is defined
@@ -488,7 +488,7 @@ namespace LibDmd
 						// gray2 -> gray2
 						case FrameFormat.Gray2:
 							AssertCompatibility(source, sourceGray2, dest, destGray2, from, to);
-							SubscribeSource(sourceGray2.GetGray2Frames()
+							Subscribe(sourceGray2.GetGray2Frames()
 									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destGray2.RenderGray2);
 							break;
@@ -500,7 +500,7 @@ namespace LibDmd
 						// gray2 -> rgb24
 						case FrameFormat.Rgb24:
 							AssertCompatibility(source, sourceGray2, dest, destRgb24, from, to);
-							SubscribeSource(sourceGray2.GetGray2Frames()
+							Subscribe(sourceGray2.GetGray2Frames()
 									.Select(frame => ColorizeGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
 									.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destRgb24.RenderRgb24);
@@ -509,7 +509,7 @@ namespace LibDmd
 						// gray2 -> bitmap
 						case FrameFormat.Bitmap:
 							AssertCompatibility(source, sourceGray2, dest, destBitmap, from, to);
-							SubscribeSource(sourceGray2.GetGray2Frames()
+							Subscribe(sourceGray2.GetGray2Frames()
 									.Select(frame => ImageUtil.ConvertFromRgb24(
 										source.Dimensions.Value.Width,
 										source.Dimensions.Value.Height,
@@ -539,7 +539,7 @@ namespace LibDmd
 						// gray4 -> gray2
 						case FrameFormat.Gray2:
 							AssertCompatibility(source, sourceGray4, dest, destGray2, from, to);
-							SubscribeSource(sourceGray4.GetGray4Frames()
+							Subscribe(sourceGray4.GetGray4Frames()
 									.Select(frame => FrameUtil.ConvertGrayToGray(frame, new byte[] { 0x0, 0x0, 0x0, 0x0, 0x1, 0x1, 0x1, 0x1, 0x2, 0x2, 0x2, 0x2, 0x3, 0x3, 0x3, 0x3 }))
 									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destGray2.RenderGray2);
@@ -548,7 +548,7 @@ namespace LibDmd
 						// gray4 -> gray4
 						case FrameFormat.Gray4:
 							AssertCompatibility(source, sourceGray4, dest, destGray4, from, to);
-							SubscribeSource(sourceGray4.GetGray4Frames()
+							Subscribe(sourceGray4.GetGray4Frames()
 									.Select(frame => TransformGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destGray4.RenderGray4);
 							break;
@@ -556,7 +556,7 @@ namespace LibDmd
 						// gray4 -> rgb24
 						case FrameFormat.Rgb24:
 							AssertCompatibility(source, sourceGray4, dest, destRgb24, from, to);
-							SubscribeSource(sourceGray4.GetGray4Frames()
+							Subscribe(sourceGray4.GetGray4Frames()
 									.Select(frame => ColorizeGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
 									.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destRgb24.RenderRgb24);
@@ -565,7 +565,7 @@ namespace LibDmd
 						// gray4 -> bitmap
 						case FrameFormat.Bitmap:
 							AssertCompatibility(source, sourceGray4, dest, destBitmap, from, to);
-							SubscribeSource(sourceGray4.GetGray4Frames()
+							Subscribe(sourceGray4.GetGray4Frames()
 									.Select(frame => ImageUtil.ConvertFromRgb24(
 										source.Dimensions.Value.Width,
 										source.Dimensions.Value.Height,
@@ -595,7 +595,7 @@ namespace LibDmd
 						// rgb24 -> gray2
 						case FrameFormat.Gray2:
 							AssertCompatibility(source, sourceRgb24, dest, destGray2, from, to);
-							SubscribeSource(sourceRgb24.GetRgb24Frames()
+							Subscribe(sourceRgb24.GetRgb24Frames()
 									.Select(frame => ImageUtil.ConvertToGray(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, 4))
 									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destGray2.RenderGray2);
@@ -604,7 +604,7 @@ namespace LibDmd
 						// rgb24 -> gray4
 						case FrameFormat.Gray4:
 							AssertCompatibility(source, sourceRgb24, dest, destGray4, from, to);
-							SubscribeSource(sourceRgb24.GetRgb24Frames()
+							Subscribe(sourceRgb24.GetRgb24Frames()
 									.Select(frame => ImageUtil.ConvertToGray(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, 16))
 									.Select(frame => TransformGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destGray4.RenderGray4);
@@ -613,7 +613,7 @@ namespace LibDmd
 						// rgb24 -> rgb24
 						case FrameFormat.Rgb24:
 							AssertCompatibility(source, sourceRgb24, dest, destRgb24, from, to);
-							SubscribeSource(sourceRgb24.GetRgb24Frames()
+							Subscribe(sourceRgb24.GetRgb24Frames()
 									.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destRgb24.RenderRgb24);
 							break;
@@ -621,7 +621,7 @@ namespace LibDmd
 						// rgb24 -> bitmap
 						case FrameFormat.Bitmap:
 							AssertCompatibility(source, sourceRgb24, dest, destBitmap, from, to);
-							SubscribeSource(sourceRgb24.GetRgb24Frames()
+							Subscribe(sourceRgb24.GetRgb24Frames()
 									.Select(frame => ImageUtil.ConvertFromRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
 									.Select(bmp => Transform(bmp, destFixedSize)),
 								destBitmap.RenderBitmap);
@@ -647,7 +647,7 @@ namespace LibDmd
 						// bitmap -> gray2
 						case FrameFormat.Gray2:
 							AssertCompatibility(source, sourceBitmap, dest, destGray2, from, to);
-							SubscribeSource(sourceBitmap.GetBitmapFrames()
+							Subscribe(sourceBitmap.GetBitmapFrames()
 									.Select(bmp => ImageUtil.ConvertToGray2(bmp))
 									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destGray2.RenderGray2);
@@ -656,7 +656,7 @@ namespace LibDmd
 						// bitmap -> gray4
 						case FrameFormat.Gray4:
 							AssertCompatibility(source, sourceBitmap, dest, destGray4, from, to);
-							SubscribeSource(sourceBitmap.GetBitmapFrames()
+							Subscribe(sourceBitmap.GetBitmapFrames()
 									.Select(bmp => ImageUtil.ConvertToGray4(bmp))
 									.Select(frame => TransformGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destGray4.RenderGray4);
@@ -665,7 +665,7 @@ namespace LibDmd
 						// bitmap -> rgb24
 						case FrameFormat.Rgb24:
 							AssertCompatibility(source, sourceBitmap, dest, destRgb24, from, to);
-							SubscribeSource(sourceBitmap.GetBitmapFrames()
+							Subscribe(sourceBitmap.GetBitmapFrames()
 									.Select(bmp => ImageUtil.ConvertToRgb24(bmp))
 									.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destRgb24.RenderRgb24);
@@ -674,7 +674,7 @@ namespace LibDmd
 						// bitmap -> bitmap
 						case FrameFormat.Bitmap:
 							AssertCompatibility(Source, sourceBitmap, dest, destBitmap, from, to);
-							SubscribeSource(sourceBitmap.GetBitmapFrames()
+							Subscribe(sourceBitmap.GetBitmapFrames()
 									.Select(bmp => Transform(bmp, destFixedSize)),
 								destBitmap.RenderBitmap);
 							break;
@@ -700,7 +700,7 @@ namespace LibDmd
 						// colored gray2 -> gray2
 						case FrameFormat.Gray2:
 							AssertCompatibility(source, sourceColoredGray2, dest, destGray2, from, to);
-							SubscribeSource(sourceColoredGray2.GetColoredGray2Frames()
+							Subscribe(sourceColoredGray2.GetColoredGray2Frames()
 									.Select(x => FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1))
 									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destGray2.RenderGray2);
@@ -713,7 +713,7 @@ namespace LibDmd
 						// colored gray2 -> rgb24
 						case FrameFormat.Rgb24:
 							AssertCompatibility(source, sourceColoredGray2, dest, destRgb24, from, to);
-							SubscribeSource(sourceColoredGray2.GetColoredGray2Frames()
+							Subscribe(sourceColoredGray2.GetColoredGray2Frames()
 									.Select(x => ColorUtil.ColorizeFrame(
 										source.Dimensions.Value.Width,
 										source.Dimensions.Value.Height, 
@@ -727,7 +727,7 @@ namespace LibDmd
 						// colored gray2 -> bitmap
 						case FrameFormat.Bitmap:
 							AssertCompatibility(source, sourceColoredGray2, dest, destBitmap, from, to);
-							SubscribeSource(sourceColoredGray2.GetColoredGray2Frames()
+							Subscribe(sourceColoredGray2.GetColoredGray2Frames()
 									.Select(x => ColorUtil.ColorizeFrame(
 										source.Dimensions.Value.Width,
 										source.Dimensions.Value.Height,
@@ -742,7 +742,7 @@ namespace LibDmd
 						// colored gray2 -> colored gray2
 						case FrameFormat.ColoredGray2:
 							AssertCompatibility(source, sourceColoredGray2, dest, destColoredGray2, from, to);
-							SubscribeSource(sourceColoredGray2.GetColoredGray2Frames()
+							Subscribe(sourceColoredGray2.GetColoredGray2Frames()
 									.Select(x => TransformColoredGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1, x.Item2, destFixedSize)),
 								x => destColoredGray2.RenderColoredGray2(x.Item1, x.Item2));
 							break;
@@ -764,7 +764,7 @@ namespace LibDmd
 						// colored gray4 -> gray2
 						case FrameFormat.Gray2:
 							AssertCompatibility(source, sourceColoredGray4, dest, destGray2, from, to);
-							SubscribeSource(sourceColoredGray4.GetColoredGray4Frames()
+							Subscribe(sourceColoredGray4.GetColoredGray4Frames()
 									.Select(x => FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1))
 									.Select(frame => FrameUtil.ConvertGrayToGray(frame, new byte[] { 0x0, 0x0, 0x0, 0x0, 0x1, 0x1, 0x1, 0x1, 0x2, 0x2, 0x2, 0x2, 0x3, 0x3, 0x3, 0x3 }))
 									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
@@ -774,7 +774,7 @@ namespace LibDmd
 						// colored gray4 -> gray4
 						case FrameFormat.Gray4:
 							AssertCompatibility(source, sourceColoredGray4, dest, destGray4, from, to);
-							SubscribeSource(sourceColoredGray4.GetColoredGray4Frames()
+							Subscribe(sourceColoredGray4.GetColoredGray4Frames()
 									.Select(x => FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1))
 									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destGray4.RenderGray4);
@@ -783,7 +783,7 @@ namespace LibDmd
 						// colored gray4 -> rgb24
 						case FrameFormat.Rgb24:
 							AssertCompatibility(source, sourceColoredGray4, dest, destRgb24, from, to);
-							SubscribeSource(sourceColoredGray4.GetColoredGray4Frames()
+							Subscribe(sourceColoredGray4.GetColoredGray4Frames()
 									.Select(x => ColorUtil.ColorizeFrame(
 										source.Dimensions.Value.Width,
 										source.Dimensions.Value.Height,
@@ -797,7 +797,7 @@ namespace LibDmd
 						// colored gray4 -> bitmap
 						case FrameFormat.Bitmap:
 							AssertCompatibility(source, sourceColoredGray4, dest, destBitmap, from, to);
-							SubscribeSource(
+							Subscribe(
 								sourceColoredGray4.GetColoredGray4Frames()
 									.Select(x => ColorUtil.ColorizeFrame(
 										source.Dimensions.Value.Width,
@@ -817,7 +817,7 @@ namespace LibDmd
 						// colored gray4 -> colored gray4
 						case FrameFormat.ColoredGray4:
 							AssertCompatibility(source, sourceColoredGray4, dest, destColoredGray4, from, to);
-							SubscribeSource(sourceColoredGray4.GetColoredGray4Frames()
+							Subscribe(sourceColoredGray4.GetColoredGray4Frames()
 									.Select(x => TransformColoredGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1, x.Item2, destFixedSize)),
 								x => destColoredGray4.RenderColoredGray4(x.Item1, x.Item2));
 							break;
@@ -842,19 +842,19 @@ namespace LibDmd
 		/// <typeparam name="T">Frame type, already converted to match destination</typeparam>
 		/// <param name="src">Source observable</param>
 		/// <param name="onNext">Action to run on destination</param>
-		private void SubscribeSource<T>(IObservable<T> src, Action<T> onNext) where T : class
+		private void Subscribe<T>(IObservable<T> src, Action<T> onNext) where T : class
 		{
 			// always observe on default thread
 			src = src.ObserveOn(Scheduler.Default);
 
 			// set idle timeout if enabled
-			if (IdleDuration > 0) {
+			if (IdleAfter > 0) {
 
 				// So we want the sequence to continue after the timeout, which is why 
 				// IObservable.Timeout is not well suited.
 				// A better approach is to run onNext with IObservable.Do and subscribe
 				// to the timeout through IObservable.Throttle.
-				Logger.Info("Setting idle timeout to {0}ms.", IdleDuration);
+				Logger.Info("Setting idle timeout to {0}ms.", IdleAfter);
 
 				// filter dupe frames so we can actually detect the idle
 				T lastFrame = null;
@@ -886,9 +886,9 @@ namespace LibDmd
 				src = src.Do(onNext);
 
 				// but subscribe to a throttled idle action
-				src = src.Throttle(TimeSpan.FromMilliseconds(IdleDuration));
+				src = src.Throttle(TimeSpan.FromMilliseconds(IdleAfter));
 				_activeSources.Add(src.Subscribe(f => {
-					Logger.Info("Idle timeout ({0}ms), clearing display.", IdleDuration);
+					Logger.Info("Idle timeout ({0}ms), clearing display.", IdleAfter);
 					ClearDisplay();
 				}));
 

--- a/LibDmd/RenderGraph.cs
+++ b/LibDmd/RenderGraph.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.Eventing.Reader;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Windows;
-using System.Windows.Automation;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using LibDmd.Common;
@@ -27,7 +25,7 @@ namespace LibDmd
 	/// Every render graph has one <see cref="ISource"/> and one or more 
 	/// <see cref="IDestination"/>. Frames produced by the source are 
 	/// dispatched to all destinations. Sources and destinations can be re-used
-	/// in other graphs.
+	/// in other graphs (converters act as source, hence the plural).
 	/// 
 	/// It's one of the graph's duties to figure out in which format the frames
 	/// should be retrieved and sent to the destinations in the most efficient
@@ -63,7 +61,7 @@ namespace LibDmd
 		public List<IDestination> Destinations { get; set; }
 
 		/// <summary>
-		/// If set, convert bitrate. Overrides <see cref="RenderAs"/>.
+		/// If set, convert the frame format.
 		/// </summary>
 		public IConverter Converter { get; set; }
 
@@ -72,13 +70,6 @@ namespace LibDmd
 		/// producing frames.
 		/// </summary>
 		public bool IsRendering { get; set; }
-		
-		/// <summary>
-		/// Produces frames before they get send through the processors.
-		/// 
-		/// Useful for displaying them for debug purposes.
-		/// </summary>
-		public IObservable<BitmapSource> BeforeProcessed => _beforeProcessed;
 
 		/// <summary>
 		/// If set, flips the image vertically (top/down).
@@ -91,7 +82,7 @@ namespace LibDmd
 		public bool FlipHorizontally { get; set; }
 
 		/// <summary>
-		/// How the image is resized for destinations with fixed width
+		/// How the image is resized for destinations with fixed width.
 		/// </summary>
 		public ResizeMode Resize { get; set; } = ResizeMode.Stretch;
 
@@ -106,7 +97,6 @@ namespace LibDmd
 		public static readonly Color DefaultColor = Colors.OrangeRed;
 
 		private readonly CompositeDisposable _activeSources = new CompositeDisposable();
-		private readonly Subject<BitmapSource> _beforeProcessed = new Subject<BitmapSource>();
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
 		private Color[] _gray2Colors; 
@@ -120,7 +110,7 @@ namespace LibDmd
 		}
 
 		/// <summary>
-		/// Run before <see cref="StartRendering(System.Action{System.Exception})"/>
+		/// Run before <see cref="StartRendering(Action{Exception})"/>
 		/// </summary>
 		/// <remarks>
 		/// Either that or <see cref="RenderGraphCollection.Init"/> must be run. The latter does
@@ -185,7 +175,7 @@ namespace LibDmd
 		/// Expected errors end up in the provided error callback.
 		/// </remarks>
 		/// <param name="onCompleted">When the source stopped producing frames.</param>
-		///  <param name="onError">When a known error occurs.</param>
+		/// <param name="onError">When a known error occurs.</param>
 		/// <returns>An IDisposable that stops rendering when disposed.</returns>
 		public IDisposable StartRendering(Action onCompleted, Action<Exception> onError = null)
 		{
@@ -207,19 +197,20 @@ namespace LibDmd
 				if (Converter != null && HasRgb24Destination()) {
 					coloredGray2SourceConverter = Converter as IColoredGray2Source;
 					coloredGray4SourceConverter = Converter as IColoredGray4Source;
+					// ReSharper disable once SuspiciousTypeConversion.Global
 					rgb24SourceConverter = Converter as IRgb24Source;
 					
 					// send frames to converter
 					switch (Converter.From) {
 						case FrameFormat.Gray2:
 							if (sourceGray2 == null) {
-								throw new IncompatibleSourceException($"Source {Source.Name} is not 2-bit compatible which is mandatory for converter {rgb24SourceConverter?.Name}.");
+								throw new IncompatibleSourceException($"Source {Source.Name} is not 2-bit compatible which is mandatory for converter {coloredGray2SourceConverter?.Name}.");
 							}
 							_activeSources.Add(sourceGray2.GetGray2Frames().Do(Converter.Convert).Subscribe());
 							break;
 						case FrameFormat.Gray4:
 							if (sourceGray4 == null) {
-								throw new IncompatibleSourceException($"Source {Source.Name} is not 4-bit compatible which is mandatory for converter {rgb24SourceConverter?.Name}.");
+								throw new IncompatibleSourceException($"Source {Source.Name} is not 4-bit compatible which is mandatory for converter {coloredGray4SourceConverter?.Name}.");
 							}
 							_activeSources.Add(sourceGray4.GetGray4Frames().Do(Converter.Convert).Subscribe());
 							break;
@@ -228,8 +219,8 @@ namespace LibDmd
 					}
 				}
 
-				foreach (var dest in Destinations) 
-				{
+				foreach (var dest in Destinations) {
+
 					var destColoredGray2 = dest as IColoredGray2Destination;
 					var destColoredGray4 = dest as IColoredGray4Destination;
 					var destRgb24 = dest as IRgb24Destination;
@@ -239,12 +230,16 @@ namespace LibDmd
 					// output frames in different formats. For example, the ColoredGray2Colorizer
 					// outputs in ColoredGray2 or ColoredGray4, depending if data is enhanced
 					// or not.
+					//
 					// So for the output, the converter acts as ISource, implementing the specific 
 					// interfaces supported. Currently the following output sources are supported:
-					//    - IColoredGray2Source, IColoredGray4Source and IRgb24Source
+					//
+					//    IColoredGray2Source, IColoredGray4Source and IRgb24Source.
+					//
 					// Other types don't make much sense (i.e. you don't convert *down* to 
 					// IGray2Source).
-					// In the code below, those sources are linked to each destination. If a 
+					//
+					// In the block below, those sources are linked to each destination. If a 
 					// destination doesn't support a colored gray source, it tries to convert
 					// it up to RGB24, otherwise fails. For example, PinDMD3 which only supports
 					// IColoredGray2Source but not IColoredGray4Source due to bad software design
@@ -294,11 +289,11 @@ namespace LibDmd
 					// One thing to remember is that now we don't have a converter defining the
 					// input format, so the source might able to deliver multiple different formats 
 					// and the destination might be accepting multiple formats as well. 
-
-					// Since we know that a source doesn't implement any interface that would result
-					// in data loss (e.g. a 4-bit source will not implement IGray2Source), we start
-					// looking at the most performant combinations first.
-
+					//
+					// But since we know that a source doesn't implement any interface that would 
+					// result in data loss (e.g. a 4-bit source will not implement IGray2Source), we
+					// start looking at the most performant combinations first.
+					//
 					// So first we try to match the source format with the destination format. Then
 					// we go on by looking at "upscaling" convertions, e.g. if a destination only
 					// supports RGB24, then convert 2-bit to RGB24. Lastly we check "downscaling"
@@ -437,7 +432,6 @@ namespace LibDmd
 					// bitmap -> gray2
 					if (sourceBitmap != null && destGray2 != null) {
 						Connect(Source, dest, FrameFormat.Bitmap, FrameFormat.Gray2);
-						continue;
 					}
 				}
 
@@ -453,7 +447,7 @@ namespace LibDmd
 				if (onError != null) {
 					onError.Invoke(ex);
 				} else {
-					throw ex;
+					throw;
 				}
 			}
 			return new RenderDisposable(this, _activeSources);
@@ -472,6 +466,7 @@ namespace LibDmd
 		/// <param name="dest">Destination to send the data to</param>
 		/// <param name="from">Data format to read from source (incompatible source will throw exception)</param>
 		/// <param name="to">Data forma to send to destination (incompatible destination will throw exception)</param>
+		[SuppressMessage("ReSharper", "PossibleNullReferenceException")]
 		private void Connect(ISource source, IDestination dest, FrameFormat from, FrameFormat to)
 		{
 			var destFixedSize = dest as IFixedSizeDestination;
@@ -481,7 +476,7 @@ namespace LibDmd
 			var destBitmap = dest as IBitmapDestination;
 			var destColoredGray2 = dest as IColoredGray2Destination;
 			var destColoredGray4 = dest as IColoredGray4Destination;
-			Logger.Info("Connecting {0} to {1} ({2} => {3})", source.Name, dest.Name, from.ToString(), to.ToString());
+			Logger.Info("Connecting {0} to {1} ({2} => {3})", source.Name, dest.Name, @from, to);
 
 			switch (from) { 
 
@@ -494,7 +489,7 @@ namespace LibDmd
 						case FrameFormat.Gray2:
 							AssertCompatibility(source, sourceGray2, dest, destGray2, from, to);
 							SubscribeSource(sourceGray2.GetGray2Frames()
-								.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destGray2.RenderGray2);
 							break;
 
@@ -506,8 +501,8 @@ namespace LibDmd
 						case FrameFormat.Rgb24:
 							AssertCompatibility(source, sourceGray2, dest, destRgb24, from, to);
 							SubscribeSource(sourceGray2.GetGray2Frames()
-								.Select(frame => ColorizeGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
-								.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+									.Select(frame => ColorizeGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
+									.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destRgb24.RenderRgb24);
 							break;
 
@@ -835,6 +830,18 @@ namespace LibDmd
 			}
 		}
 
+		/// <summary>
+		/// Subscribes to the given source and links it to the given destination.
+		/// </summary>
+		/// 
+		/// <remarks>
+		/// This also does all the common stuff, i.e. setting the correct scheduler,
+		/// enabling idle detection, etc.
+		/// </remarks>
+		/// 
+		/// <typeparam name="T">Frame type, already converted to match destination</typeparam>
+		/// <param name="src">Source observable</param>
+		/// <param name="onNext">Action to run on destination</param>
 		private void SubscribeSource<T>(IObservable<T> src, Action<T> onNext) where T : class
 		{
 			// always observe on default thread
@@ -845,7 +852,7 @@ namespace LibDmd
 
 				// So we want the sequence to continue after the timeout, which is why 
 				// IObservable.Timeout is not well suited.
-				// A better approach is to run next with IObservable.Do and subscribe
+				// A better approach is to run onNext with IObservable.Do and subscribe
 				// to the timeout through IObservable.Throttle.
 				Logger.Info("Setting idle timeout to {0}ms.", IdleDuration);
 
@@ -883,17 +890,12 @@ namespace LibDmd
 				_activeSources.Add(src.Subscribe(f => {
 					Logger.Info("Idle timeout ({0}ms), clearing display.", IdleDuration);
 					ClearDisplay();
-				}, HandleError));
+				}));
 
 			} else {
 				// subscribe and add to active sources
-				_activeSources.Add(src.Subscribe(onNext, HandleError));
+				_activeSources.Add(src.Subscribe(onNext));
 			}
-		}
-
-		private void HandleError(Exception e)
-		{
-			Logger.Error(e, "Error during rendering.");
 		}
 
 		private byte[] ColorizeGray2(int width, int height, byte[] frame)
@@ -906,6 +908,10 @@ namespace LibDmd
 			return ColorUtil.ColorizeFrame(width, height, frame, _gray4Palette ?? _gray4Colors);
 		}
 
+		/// <summary>
+		/// Returns true if at least one of the destinations can receive RGB24 frames.
+		/// </summary>
+		/// <returns>True if RGB24 is supported, false otherwise</returns>
 		private bool HasRgb24Destination()
 		{
 			return Destinations.OfType<IRgb24Destination>().Any();
@@ -1068,6 +1074,7 @@ namespace LibDmd
 		/// <param name="dest">Original destination</param>
 		/// <param name="castedDest">Casted source, will be checked against null</param>
 		/// <param name="what">Message</param>
+		/// <param name="whatDest">Name of destination</param>
 		private static void AssertCompatibility(ISource src, object castedSource, IDestination dest, object castedDest, string what, string whatDest = null)
 		{
 			if (castedSource == null && castedDest == null) {
@@ -1088,6 +1095,7 @@ namespace LibDmd
 		/// <param name="dest">Original destination</param>
 		/// <param name="castedDest">Casted source, will be checked against null</param>
 		/// <param name="what">Message</param>
+		// ReSharper disable once UnusedParameter.Local
 		private static void AssertCompatibility(IDestination dest, object castedDest, string what)
 		{
 			if (castedDest == null) {

--- a/LibDmd/RenderGraph.cs
+++ b/LibDmd/RenderGraph.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.Eventing.Reader;
 using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
@@ -492,9 +493,9 @@ namespace LibDmd
 						// gray2 -> gray2
 						case FrameFormat.Gray2:
 							AssertCompatibility(source, sourceGray2, dest, destGray2, from, to);
-							_activeSources.Add(Common(sourceGray2.GetGray2Frames()
-								.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destGray2.RenderGray2, HandleError));
+							SubscribeSource(sourceGray2.GetGray2Frames()
+								.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destGray2.RenderGray2);
 							break;
 
 						// gray2 -> gray4
@@ -504,23 +505,23 @@ namespace LibDmd
 						// gray2 -> rgb24
 						case FrameFormat.Rgb24:
 							AssertCompatibility(source, sourceGray2, dest, destRgb24, from, to);
-							_activeSources.Add(Common(sourceGray2.GetGray2Frames()
+							SubscribeSource(sourceGray2.GetGray2Frames()
 								.Select(frame => ColorizeGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
-								.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destRgb24.RenderRgb24, HandleError));
+								.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destRgb24.RenderRgb24);
 							break;
 
 						// gray2 -> bitmap
 						case FrameFormat.Bitmap:
 							AssertCompatibility(source, sourceGray2, dest, destBitmap, from, to);
-							_activeSources.Add(Common(sourceGray2.GetGray2Frames()
-								.Select(frame => ImageUtil.ConvertFromRgb24(
-									source.Dimensions.Value.Width,
-									source.Dimensions.Value.Height,
-									ColorizeGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame)
-								))
-								.Select(bmp => Transform(bmp, destFixedSize)))
-								.Subscribe(destBitmap.RenderBitmap, HandleError));
+							SubscribeSource(sourceGray2.GetGray2Frames()
+									.Select(frame => ImageUtil.ConvertFromRgb24(
+										source.Dimensions.Value.Width,
+										source.Dimensions.Value.Height,
+										ColorizeGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame)
+									))
+									.Select(bmp => Transform(bmp, destFixedSize)),
+								destBitmap.RenderBitmap);
 							break;
 
 						// gray2 -> colored gray2
@@ -543,40 +544,40 @@ namespace LibDmd
 						// gray4 -> gray2
 						case FrameFormat.Gray2:
 							AssertCompatibility(source, sourceGray4, dest, destGray2, from, to);
-							_activeSources.Add(Common(sourceGray4.GetGray4Frames()
-								.Select(frame => FrameUtil.ConvertGrayToGray(frame, new byte[] { 0x0, 0x0, 0x0, 0x0, 0x1, 0x1, 0x1, 0x1, 0x2, 0x2, 0x2, 0x2, 0x3, 0x3, 0x3, 0x3 }))
-								.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destGray2.RenderGray2, HandleError));
+							SubscribeSource(sourceGray4.GetGray4Frames()
+									.Select(frame => FrameUtil.ConvertGrayToGray(frame, new byte[] { 0x0, 0x0, 0x0, 0x0, 0x1, 0x1, 0x1, 0x1, 0x2, 0x2, 0x2, 0x2, 0x3, 0x3, 0x3, 0x3 }))
+									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destGray2.RenderGray2);
 							break;
 
 						// gray4 -> gray4
 						case FrameFormat.Gray4:
 							AssertCompatibility(source, sourceGray4, dest, destGray4, from, to);
-							_activeSources.Add(Common(sourceGray4.GetGray4Frames()
-								.Select(frame => TransformGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destGray4.RenderGray4, HandleError));
+							SubscribeSource(sourceGray4.GetGray4Frames()
+									.Select(frame => TransformGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destGray4.RenderGray4);
 							break;
 
 						// gray4 -> rgb24
 						case FrameFormat.Rgb24:
 							AssertCompatibility(source, sourceGray4, dest, destRgb24, from, to);
-							_activeSources.Add(Common(sourceGray4.GetGray4Frames()
-								.Select(frame => ColorizeGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
-								.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destRgb24.RenderRgb24, HandleError));
+							SubscribeSource(sourceGray4.GetGray4Frames()
+									.Select(frame => ColorizeGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
+									.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destRgb24.RenderRgb24);
 							break;
 
 						// gray4 -> bitmap
 						case FrameFormat.Bitmap:
 							AssertCompatibility(source, sourceGray4, dest, destBitmap, from, to);
-							_activeSources.Add(Common(sourceGray4.GetGray4Frames()
-								.Select(frame => ImageUtil.ConvertFromRgb24(
-									source.Dimensions.Value.Width,
-									source.Dimensions.Value.Height,
-									ColorizeGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame)
-								))
-								.Select(bmp => Transform(bmp, destFixedSize)))
-								.Subscribe(destBitmap.RenderBitmap, HandleError));
+							SubscribeSource(sourceGray4.GetGray4Frames()
+									.Select(frame => ImageUtil.ConvertFromRgb24(
+										source.Dimensions.Value.Width,
+										source.Dimensions.Value.Height,
+										ColorizeGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame)
+									))
+									.Select(bmp => Transform(bmp, destFixedSize)),
+								destBitmap.RenderBitmap);
 							break;
 
 						// gray4 -> colored gray2
@@ -599,36 +600,36 @@ namespace LibDmd
 						// rgb24 -> gray2
 						case FrameFormat.Gray2:
 							AssertCompatibility(source, sourceRgb24, dest, destGray2, from, to);
-							_activeSources.Add(Common(sourceRgb24.GetRgb24Frames()
-								.Select(frame => ImageUtil.ConvertToGray(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, 4))
-								.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destGray2.RenderGray2, HandleError));
+							SubscribeSource(sourceRgb24.GetRgb24Frames()
+									.Select(frame => ImageUtil.ConvertToGray(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, 4))
+									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destGray2.RenderGray2);
 							break;
 
 						// rgb24 -> gray4
 						case FrameFormat.Gray4:
 							AssertCompatibility(source, sourceRgb24, dest, destGray4, from, to);
-							_activeSources.Add(Common(sourceRgb24.GetRgb24Frames()
-								.Select(frame => ImageUtil.ConvertToGray(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, 16))
-								.Select(frame => TransformGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destGray4.RenderGray4, HandleError));
+							SubscribeSource(sourceRgb24.GetRgb24Frames()
+									.Select(frame => ImageUtil.ConvertToGray(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, 16))
+									.Select(frame => TransformGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destGray4.RenderGray4);
 							break;
 
 						// rgb24 -> rgb24
 						case FrameFormat.Rgb24:
 							AssertCompatibility(source, sourceRgb24, dest, destRgb24, from, to);
-							_activeSources.Add(Common(sourceRgb24.GetRgb24Frames()
-								.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destRgb24.RenderRgb24, HandleError));
+							SubscribeSource(sourceRgb24.GetRgb24Frames()
+									.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destRgb24.RenderRgb24);
 							break;
 
 						// rgb24 -> bitmap
 						case FrameFormat.Bitmap:
 							AssertCompatibility(source, sourceRgb24, dest, destBitmap, from, to);
-							_activeSources.Add(Common(sourceRgb24.GetRgb24Frames()
-								.Select(frame => ImageUtil.ConvertFromRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
-								.Select(bmp => Transform(bmp, destFixedSize)))
-								.Subscribe(destBitmap.RenderBitmap, HandleError));
+							SubscribeSource(sourceRgb24.GetRgb24Frames()
+									.Select(frame => ImageUtil.ConvertFromRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
+									.Select(bmp => Transform(bmp, destFixedSize)),
+								destBitmap.RenderBitmap);
 							break;
 
 						// rgb24 -> colored gray2
@@ -651,36 +652,36 @@ namespace LibDmd
 						// bitmap -> gray2
 						case FrameFormat.Gray2:
 							AssertCompatibility(source, sourceBitmap, dest, destGray2, from, to);
-							_activeSources.Add(Common(sourceBitmap.GetBitmapFrames()
-								.Select(bmp => ImageUtil.ConvertToGray2(bmp))
-								.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destGray2.RenderGray2, HandleError));
+							SubscribeSource(sourceBitmap.GetBitmapFrames()
+									.Select(bmp => ImageUtil.ConvertToGray2(bmp))
+									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destGray2.RenderGray2);
 							break;
 
 						// bitmap -> gray4
 						case FrameFormat.Gray4:
 							AssertCompatibility(source, sourceBitmap, dest, destGray4, from, to);
-							_activeSources.Add(Common(sourceBitmap.GetBitmapFrames()
-								.Select(bmp => ImageUtil.ConvertToGray4(bmp))
-								.Select(frame => TransformGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destGray4.RenderGray4, HandleError));
+							SubscribeSource(sourceBitmap.GetBitmapFrames()
+									.Select(bmp => ImageUtil.ConvertToGray4(bmp))
+									.Select(frame => TransformGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destGray4.RenderGray4);
 							break;
 
 						// bitmap -> rgb24
 						case FrameFormat.Rgb24:
 							AssertCompatibility(source, sourceBitmap, dest, destRgb24, from, to);
-							_activeSources.Add(Common(sourceBitmap.GetBitmapFrames()
-								.Select(bmp => ImageUtil.ConvertToRgb24(bmp))
-								.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destRgb24.RenderRgb24, HandleError));
+							SubscribeSource(sourceBitmap.GetBitmapFrames()
+									.Select(bmp => ImageUtil.ConvertToRgb24(bmp))
+									.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destRgb24.RenderRgb24);
 							break;
 
 						// bitmap -> bitmap
 						case FrameFormat.Bitmap:
 							AssertCompatibility(Source, sourceBitmap, dest, destBitmap, from, to);
-							_activeSources.Add(Common(sourceBitmap.GetBitmapFrames()
-								.Select(bmp => Transform(bmp, destFixedSize)))
-								.Subscribe(destBitmap.RenderBitmap, HandleError));
+							SubscribeSource(sourceBitmap.GetBitmapFrames()
+									.Select(bmp => Transform(bmp, destFixedSize)),
+								destBitmap.RenderBitmap);
 							break;
 
 						// bitmap -> colored gray2
@@ -704,10 +705,10 @@ namespace LibDmd
 						// colored gray2 -> gray2
 						case FrameFormat.Gray2:
 							AssertCompatibility(source, sourceColoredGray2, dest, destGray2, from, to);
-							_activeSources.Add(Common(sourceColoredGray2.GetColoredGray2Frames()
-								.Select(x => FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1))
-								.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destGray2.RenderGray2, HandleError));
+							SubscribeSource(sourceColoredGray2.GetColoredGray2Frames()
+									.Select(x => FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1))
+									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destGray2.RenderGray2);
 							break;
 
 						// colored gray2 -> gray4
@@ -717,38 +718,38 @@ namespace LibDmd
 						// colored gray2 -> rgb24
 						case FrameFormat.Rgb24:
 							AssertCompatibility(source, sourceColoredGray2, dest, destRgb24, from, to);
-							_activeSources.Add(Common(sourceColoredGray2.GetColoredGray2Frames()
-								.Select(x => ColorUtil.ColorizeFrame(
-									source.Dimensions.Value.Width,
-									source.Dimensions.Value.Height, 
-									FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1), 
-									x.Item2)
-								)
-								.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destRgb24.RenderRgb24, HandleError));
+							SubscribeSource(sourceColoredGray2.GetColoredGray2Frames()
+									.Select(x => ColorUtil.ColorizeFrame(
+										source.Dimensions.Value.Width,
+										source.Dimensions.Value.Height, 
+										FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1), 
+										x.Item2)
+									)
+									.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destRgb24.RenderRgb24);
 							break;
 
 						// colored gray2 -> bitmap
 						case FrameFormat.Bitmap:
 							AssertCompatibility(source, sourceColoredGray2, dest, destBitmap, from, to);
-							_activeSources.Add(Common(sourceColoredGray2.GetColoredGray2Frames()
-								.Select(x => ColorUtil.ColorizeFrame(
-									source.Dimensions.Value.Width,
-									source.Dimensions.Value.Height,
-									FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1),
-									x.Item2)
-								)
-								.Select(frame => ImageUtil.ConvertFromRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
-								.Select(bmp => Transform(bmp, destFixedSize)))
-								.Subscribe(destBitmap.RenderBitmap, HandleError));
+							SubscribeSource(sourceColoredGray2.GetColoredGray2Frames()
+									.Select(x => ColorUtil.ColorizeFrame(
+										source.Dimensions.Value.Width,
+										source.Dimensions.Value.Height,
+										FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1),
+										x.Item2)
+									)
+									.Select(frame => ImageUtil.ConvertFromRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
+									.Select(bmp => Transform(bmp, destFixedSize)),
+								destBitmap.RenderBitmap);
 							break;
 
 						// colored gray2 -> colored gray2
 						case FrameFormat.ColoredGray2:
 							AssertCompatibility(source, sourceColoredGray2, dest, destColoredGray2, from, to);
-							_activeSources.Add(Common(sourceColoredGray2.GetColoredGray2Frames()
-								.Select(x => TransformColoredGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1, x.Item2, destFixedSize)))
-								.Subscribe(x => destColoredGray2.RenderColoredGray2(x.Item1, x.Item2), HandleError));
+							SubscribeSource(sourceColoredGray2.GetColoredGray2Frames()
+									.Select(x => TransformColoredGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1, x.Item2, destFixedSize)),
+								x => destColoredGray2.RenderColoredGray2(x.Item1, x.Item2));
 							break;
 
 						// colored gray2 -> colored gray4
@@ -768,49 +769,50 @@ namespace LibDmd
 						// colored gray4 -> gray2
 						case FrameFormat.Gray2:
 							AssertCompatibility(source, sourceColoredGray4, dest, destGray2, from, to);
-							_activeSources.Add(Common(sourceColoredGray4.GetColoredGray4Frames()
-								.Select(x => FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1))
-								.Select(frame => FrameUtil.ConvertGrayToGray(frame, new byte[] { 0x0, 0x0, 0x0, 0x0, 0x1, 0x1, 0x1, 0x1, 0x2, 0x2, 0x2, 0x2, 0x3, 0x3, 0x3, 0x3 }))
-								.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destGray2.RenderGray2, HandleError));
+							SubscribeSource(sourceColoredGray4.GetColoredGray4Frames()
+									.Select(x => FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1))
+									.Select(frame => FrameUtil.ConvertGrayToGray(frame, new byte[] { 0x0, 0x0, 0x0, 0x0, 0x1, 0x1, 0x1, 0x1, 0x2, 0x2, 0x2, 0x2, 0x3, 0x3, 0x3, 0x3 }))
+									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destGray2.RenderGray2);
 							break;
 
 						// colored gray4 -> gray4
 						case FrameFormat.Gray4:
 							AssertCompatibility(source, sourceColoredGray4, dest, destGray4, from, to);
-							_activeSources.Add(Common(sourceColoredGray4.GetColoredGray4Frames()
-								.Select(x => FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1))
-								.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destGray4.RenderGray4, HandleError));
+							SubscribeSource(sourceColoredGray4.GetColoredGray4Frames()
+									.Select(x => FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1))
+									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destGray4.RenderGray4);
 							break;
 
 						// colored gray4 -> rgb24
 						case FrameFormat.Rgb24:
 							AssertCompatibility(source, sourceColoredGray4, dest, destRgb24, from, to);
-							_activeSources.Add(Common(sourceColoredGray4.GetColoredGray4Frames()
-								.Select(x => ColorUtil.ColorizeFrame(
-									source.Dimensions.Value.Width,
-									source.Dimensions.Value.Height,
-									FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1),
-									x.Item2)
-								)
-								.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)))
-								.Subscribe(destRgb24.RenderRgb24, HandleError));
+							SubscribeSource(sourceColoredGray4.GetColoredGray4Frames()
+									.Select(x => ColorUtil.ColorizeFrame(
+										source.Dimensions.Value.Width,
+										source.Dimensions.Value.Height,
+										FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1),
+										x.Item2)
+									)
+									.Select(frame => TransformRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+								destRgb24.RenderRgb24);
 							break;
 
 						// colored gray4 -> bitmap
 						case FrameFormat.Bitmap:
 							AssertCompatibility(source, sourceColoredGray4, dest, destBitmap, from, to);
-							_activeSources.Add(Common(sourceColoredGray4.GetColoredGray4Frames()
-								.Select(x => ColorUtil.ColorizeFrame(
-									source.Dimensions.Value.Width,
-									source.Dimensions.Value.Height,
-									FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1),
-									x.Item2)
-								)
-								.Select(frame => ImageUtil.ConvertFromRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
-								.Select(bmp => Transform(bmp, destFixedSize)))
-								.Subscribe(destBitmap.RenderBitmap, HandleError));
+							SubscribeSource(
+								sourceColoredGray4.GetColoredGray4Frames()
+									.Select(x => ColorUtil.ColorizeFrame(
+										source.Dimensions.Value.Width,
+										source.Dimensions.Value.Height,
+										FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1),
+										x.Item2)
+									)
+									.Select(frame => ImageUtil.ConvertFromRgb24(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame))
+									.Select(bmp => Transform(bmp, destFixedSize)),
+								destBitmap.RenderBitmap);
 							break;
 
 						// colored gray4 -> colored gray2
@@ -820,9 +822,9 @@ namespace LibDmd
 						// colored gray4 -> colored gray4
 						case FrameFormat.ColoredGray4:
 							AssertCompatibility(source, sourceColoredGray4, dest, destColoredGray4, from, to);
-							_activeSources.Add(Common(sourceColoredGray4.GetColoredGray4Frames()
-								.Select(x => TransformColoredGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1, x.Item2, destFixedSize)))
-								.Subscribe(x => destColoredGray4.RenderColoredGray4(x.Item1, x.Item2), HandleError));
+							SubscribeSource(sourceColoredGray4.GetColoredGray4Frames()
+									.Select(x => TransformColoredGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, x.Item1, x.Item2, destFixedSize)),
+								x => destColoredGray4.RenderColoredGray4(x.Item1, x.Item2));
 							break;
 						default:
 							throw new ArgumentOutOfRangeException(nameof(to), to, null);
@@ -833,26 +835,65 @@ namespace LibDmd
 			}
 		}
 
-		private IObservable<T> Common<T>(IObservable<T> o)
+		private void SubscribeSource<T>(IObservable<T> src, Action<T> onNext) where T : class
 		{
 			// always observe on default thread
-			var result = o.ObserveOn(Scheduler.Default);
+			src = src.ObserveOn(Scheduler.Default);
 
 			// set idle timeout if enabled
 			if (IdleDuration > 0) {
-				result.Timeout(TimeSpan.FromMilliseconds(IdleDuration));
+
+				// So we want the sequence to continue after the timeout, which is why 
+				// IObservable.Timeout is not well suited.
+				// A better approach is to run next with IObservable.Do and subscribe
+				// to the timeout through IObservable.Throttle.
+				Logger.Info("Setting idle timeout to {0}ms.", IdleDuration);
+
+				// filter dupe frames so we can actually detect the idle
+				T lastFrame = null;
+				src = src.Where(f => {
+					var identical = false;
+
+					// byte arrays
+					if (f is byte[]) {
+						var frame = f as byte[];
+						identical = lastFrame != null && FrameUtil.CompareBuffers(frame, 0, lastFrame as byte[], 0, frame.Length);
+					}
+
+					// bitmaps
+					else if (f is BitmapSource) {
+						var frame = ImageUtil.ConvertToRgb24(f as BitmapSource);
+						var last = lastFrame == null ? null : ImageUtil.ConvertToRgb24(lastFrame as BitmapSource);
+						identical = last != null && FrameUtil.CompareBuffers(frame, 0, last, 0, frame.Length);
+					}
+
+					// TODO bit planes
+
+					// TODO colored bit planes
+
+					lastFrame = f;
+					return !identical;
+				});
+
+				// now render it
+				src = src.Do(onNext);
+
+				// but subscribe to a throttled idle action
+				src = src.Throttle(TimeSpan.FromMilliseconds(IdleDuration));
+				_activeSources.Add(src.Subscribe(f => {
+					Logger.Info("Idle timeout ({0}ms), clearing display.", IdleDuration);
+					ClearDisplay();
+				}, HandleError));
+
+			} else {
+				// subscribe and add to active sources
+				_activeSources.Add(src.Subscribe(onNext, HandleError));
 			}
-			return result;
 		}
 
 		private void HandleError(Exception e)
 		{
-			if (e is TimeoutException) {
-				ClearDisplay();
-
-			} else {
-				Logger.Error(e, "Error during rendering.");
-			}
+			Logger.Error(e, "Error during rendering.");
 		}
 
 		private byte[] ColorizeGray2(int width, int height, byte[] frame)


### PR DESCRIPTION
Some refactoring was needed.

The most important change was the code connecting a source with a destination in `RenderGraph`. We now have a `Subscribe()` method that sets up the subscription and contains common code. This allowed moving the scheduler setup to `Subscribe()`, avoiding the need to set it up for every connection individually.

The `Subscribe()` method now also contains everything needed to setup the idle logic. Basically what happens when the `IdleAfter` parameter is set is that instead of subscribing to passing data to the destination, we clear dupes and then pass the data using `IObservable.Do()`. Then we throttle to the idle duration and run the idle logic in the subscription. The advantage of this approach (as opposed to using `IObservable.Timeout`) is that the original source can continue providing data.

Then we either clear the screen (no `IdlePlay` set), or create a new render graph (which is disposed as soon as data comes back from the original source) with the `ImageSource` or `GifSource`.

All this is implemented in `RenderGraph` directly, so it can be used by other functions than mirror if an reasonable use cased comes up.

Feature request see #36.