### PR TITLE
Support 128x16 colorizations that have scaled output to 128x32.

### DIFF
--- a/LibDmd/Converter/Colorize/Coloring.cs
+++ b/LibDmd/Converter/Colorize/Coloring.cs
@@ -37,6 +37,7 @@ namespace LibDmd.Converter.Colorize
 			var reader = new BinaryReader(fs);
 
 			Mappings = null;
+			Masks = null;
 			Filename = filename;
 			Version = reader.ReadByte();
 			Logger.Trace("PAL[{1}] Read version as {0}", Version, reader.BaseStream.Position);
@@ -56,7 +57,6 @@ namespace LibDmd.Converter.Colorize
 			}
 
 			if (reader.BaseStream.Position == reader.BaseStream.Length) {
-				Masks = new byte[0][];
 				reader.Close();
 				return;
 			}
@@ -65,7 +65,6 @@ namespace LibDmd.Converter.Colorize
 			Logger.Trace("PAL[{1}] Read number of mappings as {0}", numMappings, reader.BaseStream.Position);
 			if (reader.BaseStream.Length - reader.BaseStream.Position < Mapping.Length * numMappings) {
 				Logger.Warn("[{1}] Missing {0} bytes for {1} masks, ignoring.", Mapping.Length * numMappings - reader.BaseStream.Length + reader.BaseStream.Position, numMappings);
-				Masks = new byte[0][];
 				reader.Close();
 				return;
 			}
@@ -80,7 +79,6 @@ namespace LibDmd.Converter.Colorize
 				if (reader.BaseStream.Position != reader.BaseStream.Length) {
 					Logger.Warn("PAL[{1}] No mappings found but there are still {0} bytes in the file!", reader.BaseStream.Length - reader.BaseStream.Position, reader.BaseStream.Position);
 				}
-				Masks = new byte[0][];
 				reader.Close();
 				return;
 			}
@@ -92,7 +90,6 @@ namespace LibDmd.Converter.Colorize
 
 				if (maskBytes != 256 && maskBytes != 512 && maskBytes != 1536) {
 					Logger.Warn("{0} bytes remaining per {1} masks.  Unknown size, ignoring.", maskBytes, numMasks);
-					Masks = new byte[0][];
 					reader.Close();
 					return;
 				}

--- a/LibDmd/Converter/Gray2Colorizer.cs
+++ b/LibDmd/Converter/Gray2Colorizer.cs
@@ -18,7 +18,7 @@ namespace LibDmd.Converter
 		public FrameFormat From { get; } = FrameFormat.Gray2;
 		public IObservable<Unit> OnResume { get; }
 		public IObservable<Unit> OnPause { get; }
-		public bool Has512ByteMask { get; set; }
+		public bool Has128x32Animation { get; set; }
 		protected readonly Subject<ColoredFrame> ColoredGray2AnimationFrames = new Subject<ColoredFrame>();
 		protected readonly Subject<ColoredFrame> ColoredGray4AnimationFrames = new Subject<ColoredFrame>();
 
@@ -70,7 +70,7 @@ namespace LibDmd.Converter
 		{
 			_coloring = coloring;
 			_animations = animations;
-			Has512ByteMask = (_coloring.Masks != null && _coloring.Masks.Length >= 1 && _coloring.Masks[0].Length == 512);
+			Has128x32Animation = (_coloring.Masks != null && _coloring.Masks.Length >= 1 && _coloring.Masks[0].Length == 512);
 			SetPalette(coloring.DefaultPalette, coloring.DefaultPaletteIndex, true);
 		}
 

--- a/LibDmd/Converter/Gray2Colorizer.cs
+++ b/LibDmd/Converter/Gray2Colorizer.cs
@@ -70,7 +70,7 @@ namespace LibDmd.Converter
 		{
 			_coloring = coloring;
 			_animations = animations;
-			Has512ByteMask = (_coloring.Mappings != null && _coloring.Masks[0].Length == 512);
+			Has512ByteMask = (_coloring.Masks != null && _coloring.Masks.Length >= 1 && _coloring.Masks[0].Length == 512);
 			SetPalette(coloring.DefaultPalette, coloring.DefaultPaletteIndex, true);
 		}
 

--- a/LibDmd/Converter/Gray2Colorizer.cs
+++ b/LibDmd/Converter/Gray2Colorizer.cs
@@ -18,7 +18,7 @@ namespace LibDmd.Converter
 		public FrameFormat From { get; } = FrameFormat.Gray2;
 		public IObservable<Unit> OnResume { get; }
 		public IObservable<Unit> OnPause { get; }
-
+		public bool Has512ByteMask { get; set; }
 		protected readonly Subject<ColoredFrame> ColoredGray2AnimationFrames = new Subject<ColoredFrame>();
 		protected readonly Subject<ColoredFrame> ColoredGray4AnimationFrames = new Subject<ColoredFrame>();
 
@@ -70,7 +70,7 @@ namespace LibDmd.Converter
 		{
 			_coloring = coloring;
 			_animations = animations;
-
+			Has512ByteMask = (_coloring.Mappings != null && _coloring.Masks[0].Length == 512);
 			SetPalette(coloring.DefaultPalette, coloring.DefaultPaletteIndex, true);
 		}
 

--- a/LibDmd/DmdDevice/DmdDevice.cs
+++ b/LibDmd/DmdDevice/DmdDevice.cs
@@ -490,7 +490,7 @@ namespace LibDmd.DmdDevice
 			if (!_isOpen) {
 				Init();
 			}
-			if (_gray2Colorizer != null && width == 128 && height == 16 && _gray2Colorizer.Has512ByteMask)
+			if (_gray2Colorizer != null && width == 128 && height == 16 && _gray2Colorizer.Has128x32Animation)
 			{
 				// Pin2DMD colorization may have 512 byte masks with a 128x16 source, 
 				// indicating this should be upsized and treated as a centered 128x32 DMD.

--- a/LibDmd/Input/PinMame/VpmGray2Source.cs
+++ b/LibDmd/Input/PinMame/VpmGray2Source.cs
@@ -22,16 +22,11 @@ namespace LibDmd.Input.PinMame
 		private readonly ISubject<Unit> _onPause = new Subject<Unit>();
 
 		private readonly Subject<byte[]> _framesGray2 = new Subject<byte[]>();
-		private byte[] _lastFrame;
-
+		
 		public void NextFrame(int width, int height, byte[] frame)
 		{
-			if (_lastFrame?.Length != frame.Length) {
-				_lastFrame = new byte[frame.Length];
-			}
 			SetDimensions(width, height);
 			_framesGray2.OnNext(frame);
-			Buffer.BlockCopy(frame, 0, _lastFrame, 0, frame.Length);
 		}
 
 		public IObservable<byte[]> GetGray2Frames()

--- a/LibDmd/Input/PinMame/VpmGray4Source.cs
+++ b/LibDmd/Input/PinMame/VpmGray4Source.cs
@@ -20,16 +20,11 @@ namespace LibDmd.Input.PinMame
 		private readonly ISubject<Unit> _onPause = new Subject<Unit>();
 
 		private readonly Subject<byte[]> _framesGray4 = new Subject<byte[]>();
-		private byte[] _lastFrame;
 
 		public void NextFrame(int width, int height, byte[] frame)
 		{
-			if (_lastFrame?.Length != frame.Length) {
-				_lastFrame = new byte[frame.Length];
-			}
 			SetDimensions(width, height);
 			_framesGray4.OnNext(frame);
-			Buffer.BlockCopy(frame, 0, _lastFrame, 0, frame.Length);
 		}
 
 		public IObservable<byte[]> GetGray4Frames()


### PR DESCRIPTION
Malenko is working on a TMNT colorization.    The Pin2DMD colorizations can treat 128x16 sources as centered 128x32 ones, allowing the colorization to effectively convert the machine to 128x32.   This pull request adds support for this scenario. 

Also removes some no longer used block copies.  