### PR TITLE
DmdDevice.Init: do nothing if already initialized

### DIFF
--- a/LibDmd/DmdDevice/DmdDevice.cs
+++ b/LibDmd/DmdDevice/DmdDevice.cs
@@ -101,8 +101,9 @@ namespace LibDmd.DmdDevice
 		/// </remarks>
 		public void Init()
 		{
-			if (_isOpen)
+			if (_isOpen) { 
 				return;
+			}
 
 			_gray2Colorizer = null;
 			_gray4Colorizer = null;

--- a/LibDmd/DmdDevice/DmdDevice.cs
+++ b/LibDmd/DmdDevice/DmdDevice.cs
@@ -101,6 +101,9 @@ namespace LibDmd.DmdDevice
 		/// </remarks>
 		public void Init()
 		{
+			if (_isOpen)
+				return;
+
 			_gray2Colorizer = null;
 			_gray4Colorizer = null;
 			_coloring = null;


### PR DESCRIPTION
This is the source of the crash when dmd-ext's dmdevice.dll is used from PinballY.  

Each time PinballY switches games, it calls PM_GameSettings(), which in turn calls IDmdDevice.Init().  The implementation of DmdDevice.Init() doesn't check if it's already initialized, so it tries to re-create all of the device interfaces.  This causes a crash.

Solution is to check if the device is inited and skip the re-initialization if so.
