### PR TITLE
fix buffer overrun in memory grabbers

### DIFF
--- a/LibDmd/Input/PinballFX/PinballFX3MemoryGrabber.cs
+++ b/LibDmd/Input/PinballFX/PinballFX3MemoryGrabber.cs
@@ -266,7 +266,7 @@ namespace LibDmd.Input.PinballFX
 			var processHandle = OpenProcess(PROCESS_VM_READ, false, gameProc.Id);
 
 			// Find DMD pointer base address offset in memory with its signature pattern.
-			IntPtr baseOffset = FindPattern(gameProc, (int)BaseAddress(gameProc), 0xFFFFFF, DMDPointerSig, 25);
+			IntPtr baseOffset = FindPattern(gameProc, (int)BaseAddress(gameProc), gameProc.MainModule.ModuleMemorySize, DMDPointerSig, 25);
 			var offsetBytes = new byte[4];
 			ReadProcessMemory((int)gameProc.Handle, (int)baseOffset, offsetBytes, offsetBytes.Length, 0);
 			_pBaseAddress = new IntPtr(BitConverter.ToInt32(offsetBytes, 0) - (int)_gameBase);
@@ -285,7 +285,7 @@ namespace LibDmd.Input.PinballFX
 			ReadProcessMemory((int)gameProc.Handle, gameBase, memoryRegion, size, 0);
 
 			// Loop into dumped memory region to find the pattern.
-			for (var x = 0; x < memoryRegion.Length; x++) {
+			for (var x = 0; x < memoryRegion.Length - bytePattern.Length; x++) {
 
 				// If we find the first pattern's byte in memory, loop through the entire array.
 				for (var y = 0; y < bytePattern.Length; y++) {

--- a/LibDmd/Input/TPAGrabber/TPAGrabber.cs
+++ b/LibDmd/Input/TPAGrabber/TPAGrabber.cs
@@ -285,10 +285,10 @@ namespace LibDmd.Input.TPAGrabber
 			var gameBase = (int)BaseAddress(gameProc);
 
 			// Retrieve DMD creation offset
-			_dmdPatch = FindPattern(gameProc, gameBase, 0xFFFFFF, DMDCreationSignature, 0) - gameBase;
+			_dmdPatch = FindPattern(gameProc, gameBase, gameProc.MainModule.ModuleMemorySize, DMDCreationSignature, 0) - gameBase;
 
 			// Retrieve game state pointer + offset
-			var gameStatePointer = FindPattern(gameProc, gameBase, 0xFFFFFF, GameStateSignature, 34);
+			var gameStatePointer = FindPattern(gameProc, gameBase, gameProc.MainModule.ModuleMemorySize, GameStateSignature, 34);
 			var pointerOffset = new byte[4];
 			ReadProcessMemory((int)gameProc.Handle, (int)gameStatePointer, pointerOffset, pointerOffset.Length, 0);
 			_gameState = new IntPtr(BitConverter.ToInt32(pointerOffset, 0) - gameBase);
@@ -304,7 +304,7 @@ namespace LibDmd.Input.TPAGrabber
 			ReadProcessMemory((int)gameProc.Handle, gameBase, memoryRegion, size, 0);
 
 			// Loop into dumped memory region to find the pattern.
-			for (var x = 0; x < memoryRegion.Length; x++) {
+			for (var x = 0; x < memoryRegion.Length - bytePattern.Length; x++) {
 
 				// If we find the first pattern's byte in memory, loop through the entire array.
 				for (var y = 0; y < bytePattern.Length; y++) {


### PR DESCRIPTION
This fixes a buffer overrun in the memory grabbers that turned up in the course of removing the Admin mode requirement (see #131, #118).  

This also uses the module load size for the DMD memory block searches rather than the apparently arbitrary fixed size (0xFFFFFF) that was used in past versions.  The fixed size was insufficient in some cases (the pattern wasn't being found) and too long in other cases (it would crash the process due to ReadProcessMemory failing).  Using the actual load size seems safer in principle and in testing.  

These fixes are independent of the Admin mode pull request and should be applied even if the Admin mode pull request isn't applied.  Some of the problems in #118 actually were rooted in these issues and had nothing in fact to do with Admin mode.  The only reason Admin mode made a difference was that it apparently changed the memory layout of the target FX3 process enough to move the DMD buffer into the right memory zone so that it could be found within the arbitrary 0xFFFFFF search space and thus avoid letting the search code run off the end of the array.
