### PR TITLE
Memory grabber refactor

### DIFF
--- a/LibDmd/Input/MemoryGrabber.cs
+++ b/LibDmd/Input/MemoryGrabber.cs
@@ -26,6 +26,13 @@ namespace LibDmd.Input
 		protected abstract IntPtr AttachGameProcess(Process p);
 
 		/// <summary>
+		/// Do the DMD capture from memory.  This is called once per frame, on
+		/// the FPS timer.
+		/// </summary>
+		/// <returns></returns>
+		protected abstract FrameType CaptureDMD();
+
+		/// <summary>
 		/// Wait time between polls for the subject process. Stops polling as soon
 		/// as the process is found.
 		///
@@ -123,8 +130,6 @@ namespace LibDmd.Input
 			return _framesObservable;
 		}
 
-		protected abstract FrameType CaptureDMD();
-
 		/// <summary>
 		/// Starts sending frames.
 		/// </summary>
@@ -154,8 +159,6 @@ namespace LibDmd.Input
 		// Reactive pause/resume observables
 		public IObservable<Unit> OnResume => _onResume;
 		public IObservable<Unit> OnPause => _onPause;
-
-
 
 		// Get the base address of a process's memory space
 		protected static IntPtr BaseAddress(Process process)

--- a/LibDmd/Input/MemoryGrabber.cs
+++ b/LibDmd/Input/MemoryGrabber.cs
@@ -76,7 +76,7 @@ namespace LibDmd.Input
 		/// 
 		private void StartPolling()
 		{
-			// enable debug privileges to gain access to FX3's memory space
+			// enable debug privileges to gain access to the target process's memory space
 			SetDebugPrivilege();
 
 			Logger.Info($"Waiting for {Name} process to start...");

--- a/LibDmd/Input/MemoryGrabber.cs
+++ b/LibDmd/Input/MemoryGrabber.cs
@@ -1,0 +1,212 @@
+﻿using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using NLog;
+
+namespace LibDmd.Input
+{
+	public abstract class MemoryGrabber<FrameType> : MemoryGrabberBase
+	{
+		/// <summary>
+		/// Determine if the given process is the subject process, and attach
+		/// to it if so.  On success, this finds the DMD struct(s) within the target
+		/// process, stores their addresses in subclass member variables as needed
+		/// to read the DMD state on an ongoing basis, establishes any required
+		/// hooks in the target process (e.g., the Pinball Arcade "code cave"), and
+		/// returns the Win32 HANDLE of the open process.  If the process isn't the
+		/// subject process, or the DMD struct(s) can't be located, returns null
+		/// (IntPtr.Zero).
+		/// </summary>
+		protected abstract IntPtr AttachGameProcess(Process p);
+
+		/// <summary>
+		/// Wait time between polls for the subject process. Stops polling as soon
+		/// as the process is found.
+		///
+		/// Can be set quite high, just about as long as it takes for subject to start.
+		/// </summary>
+		public TimeSpan PollForProcessDelay { get; set; } = TimeSpan.FromSeconds(10);
+
+		/// <summary>
+		/// Frequency with which frames are pulled off the memory.
+		/// </summary>
+		public double FramesPerSecond { get; set; } = 60;
+
+		// logger
+		protected static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+		// capturer
+		private IDisposable _capturer;
+
+		// subject process handle
+		protected IntPtr _hProcess;
+
+		/// <summary>
+		/// Search the system process list for the subject process.  Returns a Win32
+		/// HANDLE to the process on success, with the memory grabber addresses stored
+		/// and any "code cave" or other hack into the subject process space established.
+		/// Returns IntPtr.Zero if no suitable subject process can be found.
+		/// </summary>
+		protected IntPtr FindGameHandle()
+		{
+			// search the process list
+			foreach (var p in Process.GetProcesses())
+			{
+				// try this process
+				var h = AttachGameProcess(p);
+
+				// if that yielded a handle, use this proces
+				if (h != IntPtr.Zero)
+					return h;
+			}
+
+			// no matches
+			return IntPtr.Zero;
+		}
+
+		/// <summary>
+		/// Poll for the subject process to start
+		/// </summary>
+		/// 
+		private void StartPolling()
+		{
+			// enable debug privileges to gain access to FX3's memory space
+			SetDebugPrivilege();
+
+			Logger.Info($"Waiting for {Name} process to start...");
+			var success = new Subject<Unit>();
+			Observable
+				.Timer(TimeSpan.Zero, PollForProcessDelay)
+				.TakeUntil(success)
+				.Subscribe(x => {
+					_hProcess = FindGameHandle();
+					if (_hProcess != IntPtr.Zero)
+					{
+						StartCapturing();
+						success.OnNext(Unit.Default);
+					}
+				});
+		}
+
+		protected IConnectableObservable<FrameType> _framesObservable = null;
+		public virtual IConnectableObservable<FrameType> GetFrames()
+		{
+			if (_framesObservable == null)
+			{
+				_framesObservable = Observable
+					.Interval(TimeSpan.FromMilliseconds(1000 / FramesPerSecond))
+					.Select(x => 
+					{
+						// if the process has exited, stop capture
+						if (WaitForSingleObject(_hProcess, 0) == WAIT_OBJECT_0)
+						{
+							CloseHandle(_hProcess);
+							_hProcess = IntPtr.Zero;
+							StopCapturing();
+							return default(FrameType);
+						}
+
+						return CaptureDMD();
+					})
+					.Where(frame => frame != null)
+					.Publish();
+
+				StartPolling();
+			}
+
+			return _framesObservable;
+		}
+
+		protected abstract FrameType CaptureDMD();
+
+		/// <summary>
+		/// Starts sending frames.
+		/// </summary>
+		private void StartCapturing()
+		{
+			Logger.Info($"Reading DMD data from {Name}'s memory at {FramesPerSecond} fps...");
+			_capturer = _framesObservable.Connect();
+			_onResume.OnNext(Unit.Default);
+		}
+
+		/// <summary>
+		/// Stops sending frames, usually because the subject process terminated.
+		/// </summary>
+		private void StopCapturing()
+		{
+			// TODO send blank frame
+			Logger.Info($"Terminating DMD data capture from {Name}");
+			_capturer.Dispose();
+			_onPause.OnNext(Unit.Default);
+			StartPolling();
+		}
+
+		// Reactive pause/resume subjects
+		protected readonly ISubject<Unit> _onResume = new Subject<Unit>();
+		protected readonly ISubject<Unit> _onPause = new Subject<Unit>();
+
+		// Reactive pause/resume observables
+		public IObservable<Unit> OnResume => _onResume;
+		public IObservable<Unit> OnPause => _onPause;
+
+
+
+		// Get the base address of a process's memory space
+		protected static IntPtr BaseAddress(Process process)
+		{
+			var procMod = process.MainModule;
+			return procMod.BaseAddress;
+		}
+
+		// Convert a four-byte buffer read from process memory to a 32-bit pointer
+		protected static IntPtr B4ToPointer(byte[] buf)
+		{
+			return new IntPtr(BitConverter.ToInt32(buf, 0));
+		}
+
+		// Search a process's memory space for a byte pattern.  0xFF in the pattern
+		// is a wildcard that matches any single byte.
+		protected static IntPtr FindPattern(Process gameProc, IntPtr gameBaseAddr, int size, byte[] bytePattern, int offset)
+		{
+			// Create a byte array to store memory region.
+			var memoryRegion = new byte[size];
+
+			// Dump process memory into the array. 
+			ReadProcessMemory(gameProc.Handle, gameBaseAddr, memoryRegion, size, IntPtr.Zero);
+
+			// Loop into dumped memory region to find the pattern.
+			for (var x = 0; x < memoryRegion.Length - bytePattern.Length; x++)
+			{
+				// If we find the first pattern's byte in memory, loop through the entire array.
+				for (var y = 0; y < bytePattern.Length; y++)
+				{
+
+					// If pattern byte is 0xFF, this is a joker, continue pattern loop.
+					if (bytePattern[y] == 0xFF)	{
+						continue;
+					}
+
+					// If pattern byte is different than memory byte, we're not at the right place, back to the memory region loop...
+					if (bytePattern[y] != memoryRegion[x + y]) {
+						break;
+					}
+
+					// We've reached the end of the pattern array, we've found the offset.
+					if (y == bytePattern.Length - 1) { 
+						return gameBaseAddr + offset + x;
+					}
+				}
+			}
+
+			// We've reached the end of memory region, offset not found.
+			return IntPtr.Zero;
+		}
+
+	}
+}

--- a/LibDmd/Input/MemoryGrabberBase.cs
+++ b/LibDmd/Input/MemoryGrabberBase.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+namespace LibDmd.Input
+{
+	public abstract class MemoryGrabberBase : AbstractSource
+	{
+
+		#region Dll Imports
+
+		[DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
+		protected static extern bool ReadProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress, byte[] buffer, int size, IntPtr lpNumberOfBytesRead);
+
+		[DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
+		protected static extern bool WriteProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress, byte[] lpBuffer, int dwSize, IntPtr lpNumberOfBytesWritten);
+
+		[DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
+		protected static extern IntPtr OpenProcess(int dwDesiredAccess, bool bInheritHandle, int dwProcessId);
+
+		// Process access rights
+		protected const int PROCESS_VM_OPERATION = 0x0008;
+		protected const int PROCESS_VM_READ = 0x0010;
+		protected const int PROCESS_VM_WRITE = 0x0020;
+		protected const int SYNCHRONIZE = 0x00100000;
+
+		[DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
+		protected static extern IntPtr VirtualAllocEx(IntPtr hProcess, IntPtr lpAddress, int dwSize, int flAllocationType, int flProtect);
+
+		#endregion
+
+	}
+}

--- a/LibDmd/Input/PinballFX/PinballFX3MemoryGrabber.cs
+++ b/LibDmd/Input/PinballFX/PinballFX3MemoryGrabber.cs
@@ -19,137 +19,45 @@ namespace LibDmd.Input.PinballFX
 	/// Can be launched any time. Will wait with sending frames until Pinball FX3 is
 	/// launched and stop sending when it exits.
 	/// </remarks>
-	public class PinballFX3MemoryGrabber : AbstractSource, IColoredGray2Source
+	public class PinballFX3MemoryGrabber : MemoryGrabber<ColoredFrame>, IColoredGray2Source
 	{
 		public override string Name { get; } = "Pinball FX3";
 
-		public IObservable<Unit> OnResume => _onResume;
-		public IObservable<Unit> OnPause => _onPause;
-
-		/// <summary>
-		/// Wait time between polls for the Pinball FX3 process. Stops polling as soon
-		/// as the process is found.
-		///
-		/// Can be set quite high, just about as long as it takes for Pinball FX3 to start.
-		/// </summary>
-		public TimeSpan PollForProcessDelay { get; set; } = TimeSpan.FromSeconds(10);
-
-		/// <summary>
-		/// Frequency with which frames are pulled off the memory.
-		/// </summary>
-		public double FramesPerSecond { get; set; } = 60;
-
-		private IConnectableObservable<ColoredFrame> _framesColoredGray2;
-		private IDisposable _capturer;
-		private IntPtr _handle;
-		private readonly ISubject<Unit> _onResume = new Subject<Unit>();
-		private readonly ISubject<Unit> _onPause = new Subject<Unit>();
-
-		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+		public IObservable<ColoredFrame> GetColoredGray2Frames()
+		{
+			return GetFrames();
+		}
 
 		// DMD Stuff
 		private const int DMDWidth = 128;
 		private const int DMDHeight = 32;
 		private static readonly byte[] RawDMD = new byte[DMDWidth * DMDHeight];
-
-		private static readonly byte[] DMDPointerSig = new byte[] { 0x83, 0xB8, 0xE4, 0x00, 0x00, 0x00, 0x00, 0x74, 0x34, 0x8B, 0x0D, 0xFF, 0xFF, 0xFF, 0xFF, 0xE8, 0xFF, 0xFF, 0xFF, 0xFF, 0x84, 0xC0, 0x75, 0x25, 0xA1 };
-		private static IntPtr _pBaseAddress = IntPtr.Zero;
-		private static IntPtr _dmdOffset = IntPtr.Zero;
-		private static IntPtr _gameBase = IntPtr.Zero;
-		private static Color _dmdColor = Colors.OrangeRed;
-
 		private byte[] _lastFrame;
 
-		/// <summary>
-		/// Waits for the Pinball FX3 process.
-		/// </summary>
-		/// 
-		private void StartPolling()
+		// adddresses in the target process
+		private static IntPtr _pBaseAddress = IntPtr.Zero;
+		private static IntPtr _dmdAddress = IntPtr.Zero;
+		private static Color _dmdColor = Colors.OrangeRed;
+
+		protected override ColoredFrame CaptureDMD()
 		{
-			// enable debug privileges to gain access to FX3's memory space
-			SetDebugPrivilege();
-
-			Logger.Info("Waiting for Pinball FX3 to spawn...");
-			var success = new Subject<Unit>();
-			Observable
-				.Timer(TimeSpan.Zero, PollForProcessDelay)
-				.TakeUntil(success)
-				.Subscribe(x => {
-					_handle = FindGameHandle();
-					if (_handle != IntPtr.Zero) {
-						StartCapturing();
-						success.OnNext(Unit.Default);
-					}
-				});
-		}
-
-		/// <summary>
-		/// Starts sending frames.
-		/// </summary>
-		private void StartCapturing()
-		{
-			Logger.Info($"Reading DMD data from Pinball FX3's memory at {FramesPerSecond} fps...");
-			_capturer = _framesColoredGray2.Connect();
-			_onResume.OnNext(Unit.Default);
-		}
-
-		/// <summary>
-		/// Stops sending frames because we couldn't aquire the game handle anymore,
-		/// usually because Pinball FX3 was closed.
-		/// </summary>
-		private void StopCapturing()
-		{
-			// TODO send blank frame
-			_capturer.Dispose();
-			_onPause.OnNext(Unit.Default);
-			StartPolling();
-		}
-
-		public IObservable<ColoredFrame> GetColoredGray2Frames()
-		{
-			if (_framesColoredGray2!= null) {
-				return _framesColoredGray2;
-			}
-			_framesColoredGray2 = Observable
-				.Interval(TimeSpan.FromMilliseconds(1000 / FramesPerSecond))
-				.Select(x => CaptureDMD())
-				.Where(frame => frame != null)
-				.Publish();
-
-			StartPolling();
-			return _framesColoredGray2;
-
-		}
-
-
-		public ColoredFrame CaptureDMD()
-		{
-			// if the process has exited, stop capture
-			if (WaitForSingleObject(_handle, 0) == WAIT_OBJECT_0)
-			{
-				CloseHandle(_handle);
-				_handle = IntPtr.Zero;
-				StopCapturing();
-				return null;
-			}
-
 			// Initialize a new writeable bitmap to receive DMD pixels.
 			var frame = new byte[DMDWidth * DMDHeight];
 
 			// Check if a table is loaded... and retrieve DMD offset in memory.
-			_dmdOffset = GetDMDOffset((int)_handle);
+			_dmdAddress = GetDMDOffset(_hProcess);
 
 			// ..if not, return an empty frame (blank DMD).
-			if (_dmdOffset == IntPtr.Zero) {
+			if (_dmdAddress == IntPtr.Zero) {
 				return new ColoredFrame(128, 32, frame, Color.FromRgb(0, 0, 0));
 			}
 
 			// Retrieve DMD color from memory.
-			_dmdColor = GetDMDColor((int)_handle); // Return RGB hex color value of DMD (return null value if the color cannot be retrieved). 
+			_dmdColor = GetDMDColor(_hProcess);    // Return RGB hex color value of DMD (return null value if the color cannot be retrieved). 
 												   // TODO - APPLY COLOR TO THE DMD
 
 			// Grab the whole raw DMD block from game's memory.
-			ReadProcessMemory((int)_handle, (int)_dmdOffset, RawDMD, RawDMD.Length, 0);
+			ReadProcessMemory(_hProcess, _dmdAddress, RawDMD, RawDMD.Length, IntPtr.Zero);
 
 			// Used to parse pixel bytes of the DMD memory block.
 			var rawPixelIndex = 0;
@@ -194,46 +102,35 @@ namespace LibDmd.Input.PinballFX
 			return identical ? null : new ColoredFrame(128, 32, frame, _dmdColor);
 		}
 
-		// Check if the game is started and return its process handle.
-		private static IntPtr FindGameHandle()
+		// try attaching to a process
+		protected override IntPtr AttachGameProcess(Process p)
 		{
-			var processList = Process.GetProcesses();
-			foreach (var p in processList) {
-				if (p.ProcessName == "Pinball FX3") {
-					// When the process is found, retrieve DMD pointer base address and return process handle.
-					return GetPointerBaseAddress(p); // This func returns process handle.
-				}
+			if (p.ProcessName == "Pinball FX3") {
+				return GetPointerBaseAddress(p);
 			}
 			return IntPtr.Zero;
 		}
 
-		// Helper function to retrieve process base address.
-		private static IntPtr BaseAddress(Process process)
-		{
-			var procMod = process.MainModule;
-			return procMod.BaseAddress;
-		}
-
-		private static IntPtr GetDMDOffset(int processHandle)
+		private static IntPtr GetDMDOffset(IntPtr hProcess)
 		{
 			// Retrieve DMD offset in memory using pointers.
-			var pAddress = new byte[4];
-			ReadProcessMemory(processHandle, (int)_gameBase + (int)_pBaseAddress, pAddress, pAddress.Length, 0);
-			ReadProcessMemory(processHandle, BitConverter.ToInt32(pAddress, 0) + 0xE8, pAddress, pAddress.Length, 0);
-			ReadProcessMemory(processHandle, BitConverter.ToInt32(pAddress, 0) + 0x34, pAddress, pAddress.Length, 0);
-			return new IntPtr(BitConverter.ToInt32(pAddress, 0));
+			var buf = new byte[4];
+			ReadProcessMemory(hProcess, _pBaseAddress, buf, buf.Length, IntPtr.Zero);
+			ReadProcessMemory(hProcess, B4ToPointer(buf) + 0xE8, buf, buf.Length, IntPtr.Zero);
+			ReadProcessMemory(hProcess, B4ToPointer(buf) + 0x34, buf, buf.Length, IntPtr.Zero);
+			return B4ToPointer(buf);
 		}
 
-		private static Color GetDMDColor(int processHandle)
+		private static Color GetDMDColor(IntPtr hProcess)
 		{
 			// Retrieve DMD color in memory using pointers.
 			var pAddress = new byte[4];
 			var colorBytes = new byte[4];
-			ReadProcessMemory(processHandle, (int)_gameBase + (int)_pBaseAddress, pAddress, pAddress.Length, 0);
-			ReadProcessMemory(processHandle, BitConverter.ToInt32(pAddress, 0) + 0xE8, pAddress, pAddress.Length, 0);
-			ReadProcessMemory(processHandle, BitConverter.ToInt32(pAddress, 0) + 0x64, pAddress, pAddress.Length, 0);
-			ReadProcessMemory(processHandle, BitConverter.ToInt32(pAddress, 0) + 0x184, pAddress, pAddress.Length, 0);
-			ReadProcessMemory(processHandle, BitConverter.ToInt32(pAddress, 0), colorBytes, colorBytes.Length, 0);
+			ReadProcessMemory(hProcess, _pBaseAddress, pAddress, pAddress.Length, IntPtr.Zero);
+			ReadProcessMemory(hProcess, B4ToPointer(pAddress) + 0xE8, pAddress, pAddress.Length, IntPtr.Zero);
+			ReadProcessMemory(hProcess, B4ToPointer(pAddress) + 0x64, pAddress, pAddress.Length, IntPtr.Zero);
+			ReadProcessMemory(hProcess, B4ToPointer(pAddress) + 0x184, pAddress, pAddress.Length, IntPtr.Zero);
+			ReadProcessMemory(hProcess, B4ToPointer(pAddress), colorBytes, colorBytes.Length, IntPtr.Zero);
 			if (BitConverter.IsLittleEndian) Array.Reverse(colorBytes);
 			var colorCode = BitConverter.ToInt32(colorBytes, 0);
 
@@ -260,78 +157,25 @@ namespace LibDmd.Input.PinballFX
 			}
 		}
 
+		// Byte pattern we use to identify the DMD memory struct in the FX3 process
+		private static readonly byte[] DMDPointerSig = new byte[] { 0x83, 0xB8, 0xE4, 0x00, 0x00, 0x00, 0x00, 0x74, 0x34, 0x8B, 0x0D, 0xFF, 0xFF, 0xFF, 0xFF, 0xE8, 0xFF, 0xFF, 0xFF, 0xFF, 0x84, 0xC0, 0x75, 0x25, 0xA1 };
+
 		private static IntPtr GetPointerBaseAddress(Process gameProc)
 		{
-			// Get game process base address.
-			_gameBase = BaseAddress(gameProc);
-
-			// Read access rights to the process.
-			const int PROCESS_VM_READ = 0x0010;
-			const int SYNCHRONIZE = 0x00100000;
-
-			// Open the process to allow memory operations.
+			// Open the process for wait and read operations
 			var processHandle = OpenProcess(SYNCHRONIZE | PROCESS_VM_READ, false, gameProc.Id);
 			if (processHandle == IntPtr.Zero) {
 				return processHandle;
-			}				
+			}
 
 			// Find DMD pointer base address offset in memory with its signature pattern.
-			IntPtr baseOffset = FindPattern(gameProc, (int)BaseAddress(gameProc), gameProc.MainModule.ModuleMemorySize, DMDPointerSig, 25);
-			var offsetBytes = new byte[4];
-			ReadProcessMemory((int)gameProc.Handle, (int)baseOffset, offsetBytes, offsetBytes.Length, 0);
-			_pBaseAddress = new IntPtr(BitConverter.ToInt32(offsetBytes, 0) - (int)_gameBase);
+			IntPtr baseOffset = FindPattern(gameProc, BaseAddress(gameProc), gameProc.MainModule.ModuleMemorySize, DMDPointerSig, 25);
+			var pointerBuf = new byte[4];
+			ReadProcessMemory(gameProc.Handle, baseOffset, pointerBuf, pointerBuf.Length, IntPtr.Zero);
+			_pBaseAddress = B4ToPointer(pointerBuf);
 
 			// Return game's process handle.
 			return processHandle;
 		}
-
-		// Function to search byte pattern in process memory then return its offset.
-		private static IntPtr FindPattern(Process gameProc, int gameBase, int size, byte[] bytePattern, int offset)
-		{
-			// Create a byte array to store memory region.
-			var memoryRegion = new byte[size];
-
-			// Dump process memory into the array. 
-			ReadProcessMemory((int)gameProc.Handle, gameBase, memoryRegion, size, 0);
-
-			// Loop into dumped memory region to find the pattern.
-			for (var x = 0; x < memoryRegion.Length - bytePattern.Length; x++) {
-
-				// If we find the first pattern's byte in memory, loop through the entire array.
-				for (var y = 0; y < bytePattern.Length; y++) {
-
-					// If pattern byte is 0xFF, this is a joker, continue pattern loop.
-					if (bytePattern[y] == 0xFF) {
-						continue;
-					}
-					// If pattern byte is different than memory byte, we're not at the right place, back to the memory region loop...
-					if (bytePattern[y] != memoryRegion[x + y]) {
-						break;
-					}
-					// We've reached the end of the pattern array, we've found the offset.
-					if (y == bytePattern.Length - 1)
-						return new IntPtr(gameBase + offset + x); // Return the offset.
-				}
-			}
-			// We've reached the end of memory region, offset not found.
-			return IntPtr.Zero;
-		}
-
-		#region Dll Imports
-
-		[DllImport("kernel32.dll")]
-		public static extern bool ReadProcessMemory(int hProcess, int lpBaseAddress, byte[] buffer, int size, int lpNumberOfBytesRead);
-
-		[DllImport("kernel32.dll")]
-		static extern bool WriteProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress, byte[] lpBuffer, int dwSize, int lpNumberOfBytesWritten);
-
-		[DllImport("kernel32.dll")]
-		public static extern IntPtr OpenProcess(int dwDesiredAccess, bool bInheritHandle, int dwProcessId);
-
-		[DllImport("kernel32.dll")]
-		public static extern IntPtr VirtualAllocEx(IntPtr hProcess, IntPtr lpAddress, int dwSize, int flAllocationType, int flProtect);
-
-		#endregion
-
 	}
 }

--- a/LibDmd/LibDmd.csproj
+++ b/LibDmd/LibDmd.csproj
@@ -201,6 +201,8 @@
     <Compile Include="Input\IGray2Source.cs" />
     <Compile Include="Input\IRgb24Source.cs" />
     <Compile Include="Input\IGray4Source.cs" />
+    <Compile Include="Input\MemoryGrabber.cs" />
+    <Compile Include="Input\MemoryGrabberBase.cs" />
     <Compile Include="Input\PinballFX\PinballFX3MemoryGrabber.cs" />
     <Compile Include="Input\PinballFX\PinballFX3Grabber.cs" />
     <Compile Include="Input\PinballFX\PinballFX2Grabber.cs" />


### PR DESCRIPTION
This refactors the TPA and FX3 memory grabbers so that they use a common base class, per my suggestion in #133.  I moved as much of the generic code as possible into the base class, so the individual grabbers are pretty well stripped down to just the target-specific operations to hack into the subject process memory.  The basic grabber mechanism is all in common code now.  I think this will make the grabbers more maintainable in the future, and will also make it a lot easier to write new grabbers that become interesting.

I also cleaned up the muddle about pointers vs offsets, and fixed all of the dllimport signatures to match the actual DLL exports.  That's a hard requirement for x64, because 'int' and 'IntPtr' are different sizes in that context, but it also cleans up a bunch of unnecessary (int) and (IntPtr) casts.  

The final code isn't exactly elegant, in that the whole thing we're doing here is an egregious hack, but it at least shrinks the ugly parts down and quarantines them into isolated modules for the individual target programs.  This makes it a lot clearer what's going on, I think.

I've tested this with TPA; I don't have FX3 to test with, so someone else should test that before this is published.
