### PR TITLE
Add support for Pixelcade displays

### DIFF
--- a/Console/Common/BaseCommand.cs
+++ b/Console/Common/BaseCommand.cs
@@ -56,7 +56,7 @@ namespace DmdExt.Common
 				}
 			}
 
-			if (config.PinDmd3.Enabled) {
+			/*if (config.PinDmd3.Enabled) {
 				var pinDmd3 = PinDmd3.GetInstance(config.PinDmd3.Port);
 				if (pinDmd3.IsAvailable) {
 					renderers.Add(pinDmd3);
@@ -74,10 +74,10 @@ namespace DmdExt.Common
 				} else {
 					Logger.Warn("Device {0} is not available.", PIN2DMD);
 				}
-			}
+			}*/
 
 			if (config.Pixelcade.Enabled) {
-				var pixelcade = Pixelcade.GetInstance(config.Pixelcade.Port);
+				var pixelcade = Pixelcade.GetInstance(config.Pixelcade.Port, config.Pixelcade.ColorMatrix);
 				if (pixelcade.IsAvailable) {
 					renderers.Add(pixelcade);
 					Logger.Info("Added Pixelcade renderer.");

--- a/Console/Common/BaseCommand.cs
+++ b/Console/Common/BaseCommand.cs
@@ -11,6 +11,7 @@ using LibDmd.Output.Pin2Dmd;
 using LibDmd.Output.PinDmd1;
 using LibDmd.Output.PinDmd2;
 using LibDmd.Output.PinDmd3;
+using LibDmd.Output.Pixelcade;
 using LibDmd.Output.Virtual.AlphaNumeric;
 using NLog;
 using static System.Windows.Threading.Dispatcher;
@@ -72,6 +73,16 @@ namespace DmdExt.Common
 					Logger.Info("Added PIN2DMD renderer.");
 				} else {
 					Logger.Warn("Device {0} is not available.", PIN2DMD);
+				}
+			}
+
+			if (config.Pixelcade.Enabled) {
+				var pixelcade = Pixelcade.GetInstance(config.Pixelcade.Port);
+				if (pixelcade.IsAvailable) {
+					renderers.Add(pixelcade);
+					Logger.Info("Added Pixelcade renderer.");
+				} else {
+					Logger.Warn("Device Pixelcade is not available.");
 				}
 			}
 

--- a/Console/Common/BaseCommand.cs
+++ b/Console/Common/BaseCommand.cs
@@ -56,7 +56,7 @@ namespace DmdExt.Common
 				}
 			}
 
-			/*if (config.PinDmd3.Enabled) {
+			if (config.PinDmd3.Enabled) {
 				var pinDmd3 = PinDmd3.GetInstance(config.PinDmd3.Port);
 				if (pinDmd3.IsAvailable) {
 					renderers.Add(pinDmd3);
@@ -74,7 +74,7 @@ namespace DmdExt.Common
 				} else {
 					Logger.Warn("Device {0} is not available.", PIN2DMD);
 				}
-			}*/
+			}
 
 			if (config.Pixelcade.Enabled) {
 				var pixelcade = Pixelcade.GetInstance(config.Pixelcade.Port, config.Pixelcade.ColorMatrix);

--- a/Console/Common/BaseOptions.cs
+++ b/Console/Common/BaseOptions.cs
@@ -4,6 +4,7 @@ using LibDmd.Common;
 using LibDmd.DmdDevice;
 using LibDmd.Input;
 using LibDmd.Output.Virtual.AlphaNumeric;
+using NLog.LayoutRenderers;
 
 namespace DmdExt.Common
 {
@@ -59,6 +60,9 @@ namespace DmdExt.Common
 
 		[Option("use-ini", HelpText = "If set, use options from DmdDevice.ini.")]
 		public string DmdDeviceIni { get; set; } = null;
+
+		[Option("color-matrix", HelpText = "Color matrix to use for Pixelcade displays. Default: RGB.")]
+		public ColorMatrix ColorMatrix { get; set; } = ColorMatrix.Rgb;
 
 		public IGlobalConfig Global { get; }
 		public IVirtualDmdConfig VirtualDmd { get; }
@@ -244,6 +248,7 @@ namespace DmdExt.Common
 		public bool Enabled => _options.Destination == BaseOptions.DestinationType.Auto ||
 		                       _options.Destination == BaseOptions.DestinationType.PIXELCADE;
 		public string Port => _options.Port;
+		public ColorMatrix ColorMatrix => _options.ColorMatrix;
 	}
 
 	internal class VideoOptions : IVideoConfig

--- a/Console/Common/BaseOptions.cs
+++ b/Console/Common/BaseOptions.cs
@@ -62,7 +62,7 @@ namespace DmdExt.Common
 		public string DmdDeviceIni { get; set; } = null;
 
 		[Option("color-matrix", HelpText = "Color matrix to use for Pixelcade displays. Default: RGB.")]
-		public ColorMatrix ColorMatrix { get; set; } = ColorMatrix.Rgb;
+		public ColorMatrix ColorMatrix { get; set; } = ColorMatrix.Rbg;
 
 		public IGlobalConfig Global { get; }
 		public IVirtualDmdConfig VirtualDmd { get; }

--- a/Console/Common/BaseOptions.cs
+++ b/Console/Common/BaseOptions.cs
@@ -67,6 +67,7 @@ namespace DmdExt.Common
 		public IPinDmd2Config PinDmd2 { get; }
 		public IPinDmd3Config PinDmd3 { get; }
 		public IPin2DmdConfig Pin2Dmd { get; }
+		public IPixelcadeConfig Pixelcade { get; }
 		public IVideoConfig Video { get; }
 		public IGifConfig Gif { get; }
 		public IBitmapConfig Bitmap { get; }
@@ -83,6 +84,7 @@ namespace DmdExt.Common
 			PinDmd2 = new PinDmd2Options(this);
 			PinDmd3 = new PinDmd3Options(this);
 			Pin2Dmd = new Pin2DmdOptions(this);
+			Pixelcade = new PixelcadeOptions(this);
 			Video = new VideoOptions();
 			Gif = new GifOptions();
 			Bitmap = new BitmapOptions(this);
@@ -93,7 +95,7 @@ namespace DmdExt.Common
 
 		public enum DestinationType
 		{
-			Auto, PinDMDv1, PinDMDv2, PinDMDv3, PIN2DMD, Virtual, AlphaNumeric
+			Auto, PinDMDv1, PinDMDv2, PinDMDv3, PIN2DMD, PIXELCADE, Virtual, AlphaNumeric
 		}
 
 		public void Validate()
@@ -228,6 +230,20 @@ namespace DmdExt.Common
 		                       _options.Destination == BaseOptions.DestinationType.PIN2DMD;
 
 		public int Delay => _options.OutputDelay;
+	}
+	
+	internal class PixelcadeOptions : IPixelcadeConfig
+	{
+		private readonly BaseOptions _options;
+
+		public PixelcadeOptions(BaseOptions options)
+		{
+			_options = options;
+		}
+
+		public bool Enabled => _options.Destination == BaseOptions.DestinationType.Auto ||
+		                       _options.Destination == BaseOptions.DestinationType.PIXELCADE;
+		public string Port => _options.Port;
 	}
 
 	internal class VideoOptions : IVideoConfig

--- a/Console/Common/BaseOptions.cs
+++ b/Console/Common/BaseOptions.cs
@@ -61,7 +61,7 @@ namespace DmdExt.Common
 		[Option("use-ini", HelpText = "If set, use options from DmdDevice.ini.")]
 		public string DmdDeviceIni { get; set; } = null;
 
-		[Option("color-matrix", HelpText = "Color matrix to use for Pixelcade displays. Default: RGB.")]
+		[Option("color-matrix", HelpText = "Color matrix to use for Pixelcade displays. Default: RBG.")]
 		public ColorMatrix ColorMatrix { get; set; } = ColorMatrix.Rbg;
 
 		public IGlobalConfig Global { get; }

--- a/LibDmd/Common/FrameUtil.cs
+++ b/LibDmd/Common/FrameUtil.cs
@@ -305,7 +305,7 @@ namespace LibDmd.Common
 			return frame;
 		}
 
-		public static void SplitIntoRgbPlanes(char[] rgb565, int width, int numLogicalRows, byte[] dest) // originally "convertAdafruit()"
+		public static void SplitIntoRgbPlanes(char[] rgb565, int width, int numLogicalRows, byte[] dest, ColorMatrix colorMatrix = ColorMatrix.Rgb) // originally "convertAdafruit()"
 		{
 			var pairOffset = 16;
 			var height = rgb565.Length / width;
@@ -322,16 +322,29 @@ namespace LibDmd.Common
 					var inputIndex1 = (y + pairOffset) * width + x;
 
 					var color0 = rgb565[inputIndex0];
-					// Take the top 3 bits of each {r,g,b}
-					var r0 = (color0 >> 13) & 0x7;
-					var g0 = (color0 >> 8) & 0x7;
-					var b0 = (color0 >> 2) & 0x7;
-
 					var color1 = rgb565[inputIndex1];
-					// Take the top 3 bits of each {r,g,b}
-					var r1 = (color1 >> 13) & 0x7;
-					var g1 = (color1 >> 8) & 0x7;
-					var b1 = (color1 >> 2) & 0x7;
+
+					int r0 = 0, r1 = 0, g0 = 0, g1 = 0, b0 = 0, b1 = 0;
+					switch (colorMatrix)
+					{
+						case ColorMatrix.Rgb:
+							r0 = (color0 >> 13) & 0x7;
+							g0 = (color0 >> 8) & 0x7;
+							b0 = (color0 >> 2) & 0x7;
+							r1 = (color1 >> 13) & 0x7;
+							g1 = (color1 >> 8) & 0x7;
+							b1 = (color1 >> 2) & 0x7;
+							break;
+
+						case ColorMatrix.Rbg:
+							r0 = (color0 >> 13) & 0x7;
+							b0 = (color0 >> 8) & 0x7;
+							g0 = (color0 >> 2) & 0x7;
+							r1 = (color1 >> 13) & 0x7;
+							b1 = (color1 >> 8) & 0x7;
+							g1 = (color1 >> 2) & 0x7;
+							break;
+					}
 
 					for (var subframe = 0; subframe < 3; ++subframe) {
 						var dotPair =
@@ -564,4 +577,9 @@ namespace LibDmd.Common
 			}
 		}
 	}
+}
+
+public enum ColorMatrix
+{
+	Rgb, Rbg
 }

--- a/LibDmd/Common/FrameUtil.cs
+++ b/LibDmd/Common/FrameUtil.cs
@@ -305,7 +305,7 @@ namespace LibDmd.Common
 			return frame;
 		}
 
-		public static void SplitIntoRgbPlanes(byte[] rgb565, int width, int numLogicalRows, byte[] dest) // originally "convertAdafruit()"
+		public static void SplitIntoRgbPlanes(char[] rgb565, int width, int numLogicalRows, byte[] dest) // originally "convertAdafruit()"
 		{
 			var pairOffset = 16;
 			var height = rgb565.Length / width;

--- a/LibDmd/Common/ImageUtil.cs
+++ b/LibDmd/Common/ImageUtil.cs
@@ -475,6 +475,33 @@ namespace LibDmd.Common
 			}
 		}
 
+		/// <summary>
+		/// Convert an RGB24 array to a RGB565 array.
+		/// </summary>
+		/// <param name="width">Width of the image</param>
+		/// <param name="height">Height of the image</param>
+		/// <param name="frameRgb24">RGB24 array, from top left to bottom right</param>
+		/// <returns></returns>
+		public static byte[] ConvertToRgb565(int width, int height, byte[] frameRgb24)
+		{
+			var frame = new byte[width * height * 2];
+			var pos = 0;
+			for (var y = 0; y < height; y++) {
+				for (var x = 0; x < width * 3; x += 3) {
+					var rgbPos = y * width * 3 + x;
+					var r = frameRgb24[rgbPos];
+					var g = frameRgb24[rgbPos + 1];
+					var b = frameRgb24[rgbPos + 2];
+
+					var x1 = (r & 0xF8) | (g >> 5);          // Take 5 bits of Red component and 3 bits of G component
+					var x2 = ((g & 0x1C) << 3) | (b >> 3);   // Take remaining 3 Bits of G component and 5 bits of Blue component
+
+					frame[pos++] = (byte)x1;
+					frame[pos++] = (byte)x2;
+				}
+			}
+			return frame;
+		}
 
 		/// <summary>
 		/// Converts between pixel formats.

--- a/LibDmd/Common/ImageUtil.cs
+++ b/LibDmd/Common/ImageUtil.cs
@@ -482,9 +482,9 @@ namespace LibDmd.Common
 		/// <param name="height">Height of the image</param>
 		/// <param name="frameRgb24">RGB24 array, from top left to bottom right</param>
 		/// <returns></returns>
-		public static byte[] ConvertToRgb565(int width, int height, byte[] frameRgb24)
+		public static char[] ConvertToRgb565(int width, int height, byte[] frameRgb24)
 		{
-			var frame = new byte[width * height * 2];
+			var frame = new char[width * height];
 			var pos = 0;
 			for (var y = 0; y < height; y++) {
 				for (var x = 0; x < width * 3; x += 3) {
@@ -496,8 +496,7 @@ namespace LibDmd.Common
 					var x1 = (r & 0xF8) | (g >> 5);          // Take 5 bits of Red component and 3 bits of G component
 					var x2 = ((g & 0x1C) << 3) | (b >> 3);   // Take remaining 3 Bits of G component and 5 bits of Blue component
 
-					frame[pos++] = (byte)x1;
-					frame[pos++] = (byte)x2;
+					frame[pos++] = (char)((x1 << 8) + x2);
 				}
 			}
 			return frame;

--- a/LibDmd/DmdDevice/Configuration.cs
+++ b/LibDmd/DmdDevice/Configuration.cs
@@ -29,6 +29,7 @@ namespace LibDmd.DmdDevice
 		public IPinDmd2Config PinDmd2 { get; }
 		public IPinDmd3Config PinDmd3 { get; }
 		public IPin2DmdConfig Pin2Dmd { get; }
+		public IPixelcadeConfig Pixelcade { get; }
 		public IVideoConfig Video { get; }
 		public IGifConfig Gif { get; }
 		public IBitmapConfig Bitmap { get; }
@@ -98,6 +99,7 @@ namespace LibDmd.DmdDevice
 			PinDmd2 = new PinDmd2Config(_data, this);
 			PinDmd3 = new PinDmd3Config(_data, this);
 			Pin2Dmd = new Pin2DmdConfig(_data, this);
+			Pixelcade = new PixelcadeConfig(_data, this);
 			Video = new VideoConfig(_data, this);
 			Gif = new GifConfig(_data, this);
 			Bitmap = new BitmapConfig(_data, this);
@@ -187,6 +189,16 @@ namespace LibDmd.DmdDevice
 		public bool Enabled => GetBoolean("enabled", true);
 		public int Delay => GetInt("delay", 25);
 		public Pin2DmdConfig(IniData data, Configuration parent) : base(data, parent)
+		{
+		}
+	}
+
+	public class PixelcadeConfig : AbstractConfiguration, IPixelcadeConfig
+	{
+		public override string Name { get; } = "pixelcade";
+		public bool Enabled => GetBoolean("enabled", true);
+		public string Port => GetString("port", null);
+		public PixelcadeConfig(IniData data, Configuration parent) : base(data, parent)
 		{
 		}
 	}

--- a/LibDmd/DmdDevice/Configuration.cs
+++ b/LibDmd/DmdDevice/Configuration.cs
@@ -198,6 +198,7 @@ namespace LibDmd.DmdDevice
 		public override string Name { get; } = "pixelcade";
 		public bool Enabled => GetBoolean("enabled", true);
 		public string Port => GetString("port", null);
+		public ColorMatrix ColorMatrix => GetEnum("matrix", ColorMatrix.Rbg);
 		public PixelcadeConfig(IniData data, Configuration parent) : base(data, parent)
 		{
 		}

--- a/LibDmd/DmdDevice/Configuration.cs
+++ b/LibDmd/DmdDevice/Configuration.cs
@@ -158,7 +158,7 @@ namespace LibDmd.DmdDevice
 	public class PinDmd1Config : AbstractConfiguration, IPinDmd1Config
 	{
 		public override string Name { get; } = "pindmd1";
-		public bool Enabled => GetBoolean("enabled", true);
+		public bool Enabled => GetBoolean("enabled", false);
 		public PinDmd1Config(IniData data, Configuration parent) : base(data, parent)
 		{
 		}
@@ -167,7 +167,7 @@ namespace LibDmd.DmdDevice
 	public class PinDmd2Config : AbstractConfiguration, IPinDmd2Config
 	{
 		public override string Name { get; } = "pindmd2";
-		public bool Enabled => GetBoolean("enabled", true);
+		public bool Enabled => GetBoolean("enabled", false);
 		public PinDmd2Config(IniData data, Configuration parent) : base(data, parent)
 		{
 		}
@@ -176,7 +176,7 @@ namespace LibDmd.DmdDevice
 	public class PinDmd3Config : AbstractConfiguration, IPinDmd3Config
 	{
 		public override string Name { get; } = "pindmd3";
-		public bool Enabled => GetBoolean("enabled", true);
+		public bool Enabled => GetBoolean("enabled", false);
 		public string Port => GetString("port", null);
 		public PinDmd3Config(IniData data, Configuration parent) : base(data, parent)
 		{
@@ -186,7 +186,7 @@ namespace LibDmd.DmdDevice
 	public class Pin2DmdConfig : AbstractConfiguration, IPin2DmdConfig
 	{
 		public override string Name { get; } = "pin2dmd";
-		public bool Enabled => GetBoolean("enabled", true);
+		public bool Enabled => GetBoolean("enabled", false);
 		public int Delay => GetInt("delay", 25);
 		public Pin2DmdConfig(IniData data, Configuration parent) : base(data, parent)
 		{
@@ -196,7 +196,7 @@ namespace LibDmd.DmdDevice
 	public class PixelcadeConfig : AbstractConfiguration, IPixelcadeConfig
 	{
 		public override string Name { get; } = "pixelcade";
-		public bool Enabled => GetBoolean("enabled", true);
+		public bool Enabled => GetBoolean("enabled", false);
 		public string Port => GetString("port", null);
 		public ColorMatrix ColorMatrix => GetEnum("matrix", ColorMatrix.Rbg);
 		public PixelcadeConfig(IniData data, Configuration parent) : base(data, parent)

--- a/LibDmd/DmdDevice/DmdDevice.cs
+++ b/LibDmd/DmdDevice/DmdDevice.cs
@@ -297,7 +297,7 @@ namespace LibDmd.DmdDevice
 				}
 			}
 			if (_config.Pixelcade.Enabled) {
-				var pixelcade = Pixelcade.GetInstance(_config.Pixelcade.Port);
+				var pixelcade = Pixelcade.GetInstance(_config.Pixelcade.Port, _config.Pixelcade.ColorMatrix);
 				if (pixelcade.IsAvailable) {
 					renderers.Add(pixelcade);
 					Logger.Info("Added Pixelcade renderer.");

--- a/LibDmd/DmdDevice/DmdDevice.cs
+++ b/LibDmd/DmdDevice/DmdDevice.cs
@@ -23,6 +23,7 @@ using LibDmd.Output.PinDmd1;
 using LibDmd.Output.PinDmd2;
 using LibDmd.Output.PinDmd3;
 using LibDmd.Output.PinUp;
+using LibDmd.Output.Pixelcade;
 using LibDmd.Output.Virtual;
 using LibDmd.Output.Virtual.AlphaNumeric;
 using Microsoft.Win32;
@@ -293,6 +294,13 @@ namespace LibDmd.DmdDevice
 						pin2Dmd.PreloadPalettes(_coloring);
 					}
 					Logger.Info("Added PIN2DMD renderer.");
+				}
+			}
+			if (_config.Pixelcade.Enabled) {
+				var pixelcade = Pixelcade.GetInstance(_config.Pixelcade.Port);
+				if (pixelcade.IsAvailable) {
+					renderers.Add(pixelcade);
+					Logger.Info("Added Pixelcade renderer.");
 				}
 			}
 			if (_config.VirtualDmd.Enabled) {

--- a/LibDmd/DmdDevice/IConfiguration.cs
+++ b/LibDmd/DmdDevice/IConfiguration.cs
@@ -61,6 +61,7 @@ namespace LibDmd.DmdDevice
 	{
 		bool Enabled { get; }
 		string Port { get; }
+		ColorMatrix ColorMatrix { get; }
 	}
 
 	public interface IVirtualDmdConfig

--- a/LibDmd/DmdDevice/IConfiguration.cs
+++ b/LibDmd/DmdDevice/IConfiguration.cs
@@ -13,6 +13,7 @@ namespace LibDmd.DmdDevice
 		IPinDmd2Config PinDmd2 { get; }
 		IPinDmd3Config PinDmd3 { get; }
 		IPin2DmdConfig Pin2Dmd { get; }
+		IPixelcadeConfig Pixelcade { get; }
 		IVideoConfig Video { get; }
 		IGifConfig Gif { get; }
 		IBitmapConfig Bitmap { get; }
@@ -54,6 +55,12 @@ namespace LibDmd.DmdDevice
 	{
 		bool Enabled { get; }
 		int Delay { get; }
+	}
+
+	public interface IPixelcadeConfig
+	{
+		bool Enabled { get; }
+		string Port { get; }
 	}
 
 	public interface IVirtualDmdConfig

--- a/LibDmd/LibDmd.csproj
+++ b/LibDmd/LibDmd.csproj
@@ -206,6 +206,7 @@
     <Compile Include="ColoredFrame.cs" />
     <Compile Include="Common\CultureUtil.cs" />
     <Compile Include="DmdDevice\IConfiguration.cs" />
+    <Compile Include="Output\Pixelcade\Pixelcade.cs" />
     <Compile Include="Output\Virtual\AlphaNumeric\AlphaNumericLayerSetting.xaml.cs">
       <DependentUpon>AlphaNumericLayerSetting.xaml</DependentUpon>
     </Compile>

--- a/LibDmd/Output/Pixelcade/Pixelcade.cs
+++ b/LibDmd/Output/Pixelcade/Pixelcade.cs
@@ -1,0 +1,225 @@
+﻿using System;
+using System.IO.Ports;
+using System.Linq;
+using System.Text;
+using System.Windows.Media;
+using LibDmd.Common;
+using NLog;
+
+namespace LibDmd.Output.Pixelcade
+{
+	/// <summary>
+	/// Output target for Pixelcade devices.
+	/// </summary>
+	/// <see cref="http://pixelcade.org/"/>
+	public class Pixelcade : IRgb24Destination, IFixedSizeDestination
+	{
+		public string Name { get; } = "Pixelcade";
+		public bool IsAvailable { get; private set; }
+
+		public int Delay { get; set; } = 100;
+		public int DmdWidth { get; } = 128;
+		public int DmdHeight { get; } = 32;
+
+		private const byte RgbLedMatrixFrameCommandByte = 0x1F;
+		private const byte RgbLedMatrixEnableCommandByte = 0x1E;
+		private const byte ResponseEstablishConnection = 0x00;
+
+		/// <summary>
+		/// Firmware string read from the device if connected
+		/// </summary>
+		public string Firmware { get; private set; }
+
+		/// <summary>
+		/// Manually overriden port name. If set, don't loop through available
+		/// ports in order to find the device.
+		/// </summary>
+		public string Port { get; set; }
+
+		private static Pixelcade _instance;
+		private readonly byte[] _frameBuffer;
+		private bool _lastFrameFailed;
+
+		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+		/// <summary>
+		/// If device is initialized in raw mode, this is the raw device.
+		/// </summary>
+		private SerialPort _serialPort;
+
+		/// <summary>
+		/// Returns the current instance of the Pixelcade API.
+		/// </summary>
+		/// <returns>New or current instance</returns>
+		public static Pixelcade GetInstance()
+		{
+			if (_instance == null) {
+				_instance = new Pixelcade();
+			} 
+			_instance.Init();
+			return _instance;
+		}
+
+		/// <summary>
+		/// Returns the current instance of the Pixelcade API.
+		/// </summary>
+		/// <param name="port">Don't loop through available ports but use this COM port name.</param>
+		/// <returns>New or current instance</returns>
+		public static Pixelcade GetInstance(string port)
+		{
+			if (_instance == null) {
+				_instance = new Pixelcade { Port = port };
+			} 
+			_instance.Init();
+			return _instance;
+		}
+
+		/// <summary>
+		/// Constructor, initializes the DMD.
+		/// </summary>
+		private Pixelcade()
+		{
+			_frameBuffer = new byte[DmdHeight * DmdWidth * 3 / 2 + 1];
+			_frameBuffer[0] = RgbLedMatrixFrameCommandByte;
+		}
+
+		public void Init()
+		{
+			if (Port != null && Port.Trim().Length > 0) {
+				IsAvailable = Connect(Port);
+
+			} else {
+				var ports = SerialPort.GetPortNames();
+				foreach (var portName in ports) {
+					IsAvailable = Connect(portName);
+					if (IsAvailable) {
+						break;
+					}
+				}
+			}
+
+			if (!IsAvailable) {
+				Logger.Info("Pixelcade device not found.");
+				return;
+			}
+
+			// put the matrix into stream mode 
+			EnableRgbLedMatrix(4, 16);
+		}
+
+		private bool Connect(string port)
+		{
+			try {
+				Logger.Info("Checking port {0} for Pixelcade...", port);
+				_serialPort = new SerialPort(port, 8176000, Parity.None, 8, StopBits.One);
+				_serialPort.Open();
+				System.Threading.Thread.Sleep(Delay); // probably can remove that
+
+
+				// let's assume opening a connection results in what IncomingState.handleEstablishConnection() receives...
+				var result = new byte[1 + 4 + 8 + 8 + 8];
+				_serialPort.Read(result, 0, 1 + 4 + 8 + 8 + 8);
+				if (result[0] != ResponseEstablishConnection) {
+					throw new Exception($"Expected new connection to return 0x0, but got {result[0]}");
+				}
+
+				var magic = Encoding.UTF8.GetString(result.Skip(1).Take(4).ToArray());
+				if (magic != "IOIO") {
+					throw new Exception($"Expected magic code to equal IOIO but got {magic}");
+				}
+				var hardwareId = Encoding.UTF8.GetString(result.Skip(1+4).Take(8).ToArray());
+				var bootloaderId = Encoding.UTF8.GetString(result.Skip(1+4+8).Take(8).ToArray());
+				Firmware = Encoding.UTF8.GetString(result.Skip(1+4+8+8).Take(8).ToArray());
+				Logger.Info("Found Pixelcade device on {0}.", port);
+				Logger.Debug("   Hardware ID:   {0}", hardwareId);
+				Logger.Debug("   Bootloader ID: {0}", bootloaderId);
+				Logger.Debug("   Firmware:      {0}", Firmware);
+				return true;
+
+			} catch (Exception e) {
+				Logger.Error("Error: {0}", e.Message.Trim());
+				if (_serialPort != null && _serialPort.IsOpen) {
+					_serialPort.Close();
+				}
+			}
+			return false;
+		}
+	
+		public void RenderRgb24(byte[] frameRgb24)
+		{
+			// convert rgb24 to rgb565
+			var frame565 = ImageUtil.ConvertToRgb565(DmdWidth, DmdHeight, frameRgb24);
+
+			// split into planes to send over the wire
+			var newFrame = new byte[DmdHeight * DmdWidth * 3 / 2];
+			FrameUtil.SplitIntoRgbPlanes(frame565, DmdWidth, 16, newFrame);
+
+			// copy to frame buffer
+			var changed = FrameUtil.Copy(newFrame, _frameBuffer, 1);
+
+			// send to device if changed
+			if (changed) {
+				RenderRaw(_frameBuffer);
+			}
+		}
+
+		public void RenderRaw(byte[] data)
+		{
+			try {
+				_serialPort.Write(data, 0, data.Length);
+				_lastFrameFailed = false;
+
+			} catch (Exception e) {
+				if (!_lastFrameFailed) {
+					Logger.Error("Error writing to serial port: {0}", e.Message);
+					_lastFrameFailed = true;
+				}
+			}
+		}
+
+		public void ClearDisplay()
+		{
+			for (var i = 1; i < _frameBuffer.Length - 1; i++) {
+				_frameBuffer[i] = 0;
+			}
+			if (_serialPort.IsOpen) {
+				_serialPort.Write(_frameBuffer, 0, _frameBuffer.Length);
+			}
+		}
+
+		public void SetColor(Color color)
+		{
+			// no palette support here.
+		}
+
+		public void SetPalette(Color[] colors, int index = -1)
+		{
+			// no palette support here.
+		}
+
+		public void ClearPalette()
+		{
+			ClearColor();
+		}
+
+		public void ClearColor()
+		{
+			SetColor(RenderGraph.DefaultColor);
+		}
+
+		public void Dispose()
+		{
+			if (_serialPort.IsOpen) {
+				_serialPort.Close();
+			}
+		}
+
+		private void EnableRgbLedMatrix(int shifterLen32, int rows)
+		{
+			_serialPort.Write(new[] {
+				RgbLedMatrixEnableCommandByte, 
+				(byte)(shifterLen32 & 0x0F | ((rows == 8 ? 0 : 1) << 4))
+			}, 0, 2);
+		}
+	}
+}

--- a/LibDmd/Output/Pixelcade/Pixelcade.cs
+++ b/LibDmd/Output/Pixelcade/Pixelcade.cs
@@ -36,6 +36,11 @@ namespace LibDmd.Output.Pixelcade
 		/// </summary>
 		public string Port { get; set; }
 
+		/// <summary>
+		/// Color matrix to use, default it RGB.
+		/// </summary>
+		public ColorMatrix ColorMatrix { get; set; } = ColorMatrix.Rgb;
+
 		private static Pixelcade _instance;
 		private readonly byte[] _frameBuffer;
 		private bool _lastFrameFailed;
@@ -64,11 +69,12 @@ namespace LibDmd.Output.Pixelcade
 		/// Returns the current instance of the Pixelcade API.
 		/// </summary>
 		/// <param name="port">Don't loop through available ports but use this COM port name.</param>
+		/// <param name="colorMatrix">RGB or RBG</param>
 		/// <returns>New or current instance</returns>
-		public static Pixelcade GetInstance(string port)
+		public static Pixelcade GetInstance(string port, ColorMatrix colorMatrix)
 		{
 			if (_instance == null) {
-				_instance = new Pixelcade { Port = port };
+				_instance = new Pixelcade { Port = port, ColorMatrix = colorMatrix };
 			} 
 			_instance.Init();
 			return _instance;
@@ -159,7 +165,7 @@ namespace LibDmd.Output.Pixelcade
 
 			// split into planes to send over the wire
 			var newFrame = new byte[DmdHeight * DmdWidth * 3 / 2];
-			FrameUtil.SplitIntoRgbPlanes(frame565, DmdWidth, 16, newFrame);
+			FrameUtil.SplitIntoRgbPlanes(frame565, DmdWidth, 16, newFrame, ColorMatrix);
 
 			// copy to frame buffer
 			var changed = FrameUtil.Copy(newFrame, _frameBuffer, 1);

--- a/LibDmd/Output/Pixelcade/Pixelcade.cs
+++ b/LibDmd/Output/Pixelcade/Pixelcade.cs
@@ -20,6 +20,7 @@ namespace LibDmd.Output.Pixelcade
 		public int DmdWidth { get; } = 128;
 		public int DmdHeight { get; } = 32;
 
+		private const int ReadTimeoutMs = 500;
 		private const byte RgbLedMatrixFrameCommandByte = 0x1F;
 		private const byte RgbLedMatrixEnableCommandByte = 0x1E;
 		private const byte ResponseEstablishConnection = 0x00;
@@ -114,6 +115,7 @@ namespace LibDmd.Output.Pixelcade
 				_serialPort = new SerialPort(port);
 				_serialPort.ReceivedBytesThreshold = 1;
 				_serialPort.DtrEnable = true;
+				_serialPort.ReadTimeout = ReadTimeoutMs;
 				System.Threading.Thread.Sleep(Delay);
 				_serialPort.Open();
 

--- a/LibDmd/Output/Pixelcade/Pixelcade.cs
+++ b/LibDmd/Output/Pixelcade/Pixelcade.cs
@@ -20,7 +20,7 @@ namespace LibDmd.Output.Pixelcade
 		public int DmdWidth { get; } = 128;
 		public int DmdHeight { get; } = 32;
 
-		private const int ReadTimeoutMs = 500;
+		private const int ReadTimeoutMs = 100;
 		private const byte RgbLedMatrixFrameCommandByte = 0x1F;
 		private const byte RgbLedMatrixEnableCommandByte = 0x1E;
 		private const byte ResponseEstablishConnection = 0x00;
@@ -146,6 +146,7 @@ namespace LibDmd.Output.Pixelcade
 				Logger.Error("Error: {0}", e.Message.Trim());
 				if (_serialPort != null && _serialPort.IsOpen) {
 					_serialPort.Close();
+					System.Threading.Thread.Sleep(Delay); // otherwise the next device will fail
 				}
 			}
 			return false;

--- a/PinMameDevice/DmdDevice.ini
+++ b/PinMameDevice/DmdDevice.ini
@@ -48,6 +48,14 @@ enabled = false
 ; how long to wait in milliseconds after sending a palette
 delay = 25
 
+[pixelcade]
+; if false, doesn't bother looking for a Pixelcade
+enabled = true
+; COM port, e.g. COM3
+port = 
+; color matrix to use, either "rgb" or "rbg"
+matrix = rgb
+
 [browserstream]
 ; if enabled, stream to your browser in your LAN
 enabled = false

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Currently supported displays:
 - **PinDMD v2**, 4 bit (16 shades) support
 - **PinDMD v1**, 2 bit (4 shades) support
 - **PIN2DMD**, full RGB support
+- **Pixelcade**, full RGB support
 - **Virtual DMD** on a computer monitor, renders nice dots and is useful for 
   debugging.
 - **Alphanumeric Virtual**, a high-resolution virtual segmented display for 


### PR DESCRIPTION
This is a first implementation of the [Pixelcade](http://pixelcade.org/) RGB display. It currently addresses the device through the serial port directly.

Roughly here's what the driver's doing:

1. Loop through serial ports, connect and read bytes.
2. If bytes were read, first byte starts with `0x0`, followed by "IOIO" and 24 bytes of hardware, bootloader and firmware info, we're good to go.
3. In this case, enable "streaming mode" by sending `0x1e` and another computed byte
4. On incoming frame, convert to RGB planes, and send `0x1f` plus the data

I might have misunderstood the above from reading a lot of code of the [Java implementation](https://github.com/alinke/PIXEL). Please @alinke or @ytai feel free to chime in.