### PR TITLE
culture fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,119 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+###############################
+# Core EditorConfig Options   #
+###############################
+# top-most editorconfig files
+root = true
+# All files
+[*]
+indent_style = tab
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_prefer_inferred_tuple_names = true:suggestion
+dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+# Use PascalCase for constant fields  
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true

--- a/Console/DmdExt.cs
+++ b/Console/DmdExt.cs
@@ -12,6 +12,7 @@ using DmdExt.Mirror;
 using DmdExt.Play;
 using DmdExt.Test;
 using LibDmd;
+using LibDmd.Common;
 using LibDmd.DmdDevice;
 using LibDmd.Input.FileSystem;
 using LibDmd.Input.PinballFX;
@@ -64,6 +65,7 @@ namespace DmdExt
 				_sha = "";
 			}
 
+			CultureUtil.NormalizeUICulture();
 			_commandLineArgs = args;
 
 			// setup logger

--- a/DmdExtensions.sln
+++ b/DmdExtensions.sln
@@ -1,12 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29503.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibDmd", "LibDmd\LibDmd.csproj", "{0318CC71-57C6-4F46-9495-6CACF0CF1505}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{772736EA-B549-44D0-82C0-7086DB379527}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		README.md = README.md
 		VersionAssemblyInfo.cs = VersionAssemblyInfo.cs

--- a/LibDmd/Common/CultureUtil.cs
+++ b/LibDmd/Common/CultureUtil.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LibDmd.Common
+{
+	public static class CultureUtil
+	{
+		/// <summary>
+		/// In order to not have to deal with the inconsistencies in Windows regional/culture settings whereby decimals use either periods or commas we default to the 
+		/// InvariantCulture, which means that all formatting and parsing of strings (to/from datetime, float, double, decimal) should be parseable by a peice of software independent 
+		/// of the user's local windows settings.
+		/// This is especially important with features such as LibDmd's settings windows which read/write to configuration files.
+		/// Reference(s): https://stackoverflow.com/questions/9760237/what-does-cultureinfo-invariantculture-mean
+		/// https://stackoverflow.com/questions/13354211/how-to-set-default-culture-info-for-entire-c-sharp-application
+		/// </summary>
+		public static void NormalizeUICulture()
+		{
+			//Fix for persisting changes to config files so that decimals in non-US cultures do not get the decimal values replaced with comma's,
+			//and always remain periods.
+			CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+			CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+			Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+			Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+			//If upgrading DMDExt to .NET 4.6 or beyond, this might be required according to this: https://stackoverflow.com/questions/36312697/setting-default-currentculture-and-currentuiculture-differences-between-net-4
+			//AppContext.SetSwitch("Switch.System.Globalization.NoAsyncCurrentCulture", true);
+		}
+	}
+}

--- a/LibDmd/DmdDevice/DmdDevice.cs
+++ b/LibDmd/DmdDevice/DmdDevice.cs
@@ -95,6 +95,7 @@ namespace LibDmd.DmdDevice
 				SimpleConfigurator.ConfigureForTargetLogging(MemLogger, LogLevel.Debug);
 			}
 #endif
+			CultureUtil.NormalizeUICulture();
 			_config = new Configuration();
 			_altcolorPath = GetColorPath();
 

--- a/LibDmd/LibDmd.csproj
+++ b/LibDmd/LibDmd.csproj
@@ -204,6 +204,7 @@
     </Compile>
     <Compile Include="AlphaNumericFrame.cs" />
     <Compile Include="ColoredFrame.cs" />
+    <Compile Include="Common\CultureUtil.cs" />
     <Compile Include="DmdDevice\IConfiguration.cs" />
     <Compile Include="Output\Virtual\AlphaNumeric\AlphaNumericLayerSetting.xaml.cs">
       <DependentUpon>AlphaNumericLayerSetting.xaml</DependentUpon>

--- a/README.md
+++ b/README.md
@@ -300,6 +300,12 @@ This application is based on .NET 4.5, which only runs on Windows 7 or later.
 Probably on Vista too, but who cares. If you're still running WinXP then you
 have my sincerest sympathy, but that's as far as I go. ;)
 
+## Breaking Changes
+
+Since version 1.8 data types in configuration files are now culture invariant. Meaning if you are running under a Windows UI Culture 
+such as German which normally represents decimals with commas instead of periods you will need to change your configuration file 
+(such as DMDDevice.ini) to use periods for decimal data. The most common example would be those users who are using `dotsize` setting
+in your DMDDevice.ini. This was done to standardize the format of numeric data accross different languages.
 
 ## Troubleshooting
 
@@ -418,6 +424,15 @@ setup, however note that games that you've already configured won't be affected.
   Pinball, where the bitness of the binary must be the same as dmdext's.
 - For `dmddevice.dll` you probably want the 32-bit version unless you've set up
   VPM with `Setup64.exe` and you know what you're doing.
+
+## Compilation Notes
+
+There is an issue with Fody third party addin that may give you an error with the $(IntermediateOutputPath) if you do a fresh
+checkout of this project from Github.
+
+If this occurs, simply close Visual Studio and re-launch the DMD Extensions project and the issue will go away.
+
+[Reference](https://github.com/Fody/Fody/issues/629)
 
 ## Credits
 


### PR DESCRIPTION
@freezy This pull request should fix the language culture setting issues discussed here:
https://github.com/freezy/dmd-extensions/issues/154

Additionally I added a .editorconfig so that my visual studio settings don't interfere with your visual studio settings as I know you want the standard to be tabs in .cs files :-)

Lastly, i updated notes in the config file that version 1.8 users (which I am assuming is what you are going to version the next release as?) that they should update the DMDDevice.ini if they did make customizations to it and are under a language that represents decimals with a comma instead of a period (I only know of German that does that but there are others i'm sure).

Also, I ran into an issue with Fody on a fresh checkout, turns out it's some sort of wierd visual studio caching issue, so I put in a compilation note in the readme incase anyone else runs into that.