### PR TITLE
Add game name to browser stream

### DIFF
--- a/LibDmd/DmdDevice/DmdDevice.cs
+++ b/LibDmd/DmdDevice/DmdDevice.cs
@@ -339,7 +339,7 @@ namespace LibDmd.DmdDevice
 				renderers.Add(new VpdbStream { EndPoint = _config.VpdbStream.EndPoint });
 			}
 			if (_config.BrowserStream.Enabled) {
-				renderers.Add(new BrowserStream(_config.BrowserStream.Port));
+				renderers.Add(new BrowserStream(_gameName, _config.BrowserStream.Port));
 			}
 
 			if (renderers.Count == 0) {

--- a/LibDmd/DmdDevice/DmdDevice.cs
+++ b/LibDmd/DmdDevice/DmdDevice.cs
@@ -339,7 +339,7 @@ namespace LibDmd.DmdDevice
 				renderers.Add(new VpdbStream { EndPoint = _config.VpdbStream.EndPoint });
 			}
 			if (_config.BrowserStream.Enabled) {
-				renderers.Add(new BrowserStream(_gameName, _config.BrowserStream.Port));
+				renderers.Add(new BrowserStream(_config.BrowserStream.Port, _gameName));
 			}
 
 			if (renderers.Count == 0) {

--- a/LibDmd/Output/Network/BrowserStream.cs
+++ b/LibDmd/Output/Network/BrowserStream.cs
@@ -24,9 +24,9 @@ namespace LibDmd.Output.Network
 		private readonly Dictionary<string, string> _www = new Dictionary<string, string>(); 
 		private readonly HttpServer _server;
 		private readonly List<DmdSocket>  _sockets = new List<DmdSocket>();
-        private readonly string _gameName;
+		private readonly string _gameName;
 
-        private int _width;
+		private int _width;
 		private int _height;
 		private Color _color = RenderGraph.DefaultColor;
 		private Color[] _palette;
@@ -43,9 +43,9 @@ namespace LibDmd.Output.Network
 				.ForEach(res => _www["/" + res.Substring(prefix.Length)] = res);
 			_www["/"] = prefix + "index.html";
 
-            _gameName = romName;
+			_gameName = romName;
 
-            _server = new HttpServer(port);
+			_server = new HttpServer(port);
 			_server.OnGet += (sender, e) => {
 
 				var req = e.Request;
@@ -86,11 +86,11 @@ namespace LibDmd.Output.Network
 		public void Init(DmdSocket socket)
 		{
 			Logger.Debug("Init socket");
-            if (_gameName != null)
-            {
-                socket.SendGameName(_gameName);
-            }
-            socket.SendDimensions(_width, _height);
+			if (_gameName != null)
+			{
+				socket.SendGameName(_gameName);
+			}
+			socket.SendDimensions(_width, _height);
 			socket.SendColor(_color);
 			if (_palette != null) {
 				socket.SendPalette(_palette);
@@ -201,6 +201,11 @@ namespace LibDmd.Output.Network
 
 		public void SendGray(byte[] frame, int bitlength)
 		{
+			if (frame.Length < _width * _height)
+			{
+				Logger.Info("SendGray: invalid frame received frame.length={0} bitlength={1} width={2} height={3}", frame.Length, bitlength, _width, _height);
+				return;
+			}
 			var timestamp = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
 			var data = Encoding.ASCII
 				.GetBytes("gray" + bitlength + "Planes")
@@ -238,17 +243,17 @@ namespace LibDmd.Output.Network
 			Send(data.ToArray());
 		}
 
-        public void SendGameName(string gameName)
-        {
-            var data = Encoding.ASCII
-                .GetBytes("gameName")
-                .Concat(new byte[] { 0x0 })
-                .Concat(Encoding.ASCII.GetBytes(gameName));
-            Send(data.ToArray());
-            Logger.Info("Sent game name to socket.");
-        }
+		public void SendGameName(string gameName)
+		{
+			var data = Encoding.ASCII
+				.GetBytes("gameName")
+				.Concat(new byte[] { 0x0 })
+				.Concat(Encoding.ASCII.GetBytes(gameName));
+			Send(data.ToArray());
+			Logger.Info("Sent game name to socket.");
+		}
 
-        public void SendDimensions(int width, int height)
+		public void SendDimensions(int width, int height)
 		{
 			_width = width;
 			_height = height;

--- a/LibDmd/Output/Network/BrowserStream.cs
+++ b/LibDmd/Output/Network/BrowserStream.cs
@@ -33,7 +33,7 @@ namespace LibDmd.Output.Network
 
 		private static readonly NLog.Logger Logger = LogManager.GetCurrentClassLogger();
 
-		public BrowserStream(string romName, int port)
+		public BrowserStream(int port, string romName = null)
 		{
 			// map embedded www resources to _www
 			const string prefix = "LibDmd.Output.Network.www.";
@@ -263,7 +263,7 @@ namespace LibDmd.Output.Network
 				.Concat(BitConverter.GetBytes(width))
 				.Concat(BitConverter.GetBytes(height));
 			Send(data.ToArray());
-			Logger.Info("Sent dimensions to socket.");
+			Logger.Info("Sent dimensions to socket {0}x{1}.", width, height);
 		}
 
 		public void SendColor(Color color)


### PR DESCRIPTION
Add game name (rom) on init request to the browser stream, to allow the requester to adapt its rendering to the game.

The browser stream output allow to create fancy DMD rendering. To allow skinning based on the game rom, you need to get this information from PinMame. The most clean way is for dmdext to pull it on init request, hence this small pull request. This allows little software like [DMDOverlay](https://vpinball.com/VPBdownloads/dmd-overlay/) to be more clean and simple.