### PR TITLE
Pixel Grabber Tweaks for FX3

### DIFF
--- a/LibDmd/Input/PinballFX/PinballFXGrabber.cs
+++ b/LibDmd/Input/PinballFX/PinballFXGrabber.cs
@@ -47,10 +47,10 @@ namespace LibDmd.Input.PinballFX
 		/// </summary>
 		public double FramesPerSecond { get; set; } = 60;
 
-		public int CropLeft { get; set; } = 12;
-		public int CropTop { get; set; } = 8;
-		public int CropRight { get; set; } = 8;
-		public int CropBottom { get; set; } = 12;
+		public int CropLeft { get; set; } = 4;
+		public int CropTop { get; set; } = 4;
+		public int CropRight { get; set; } = 4;
+		public int CropBottom { get; set; } = 4;
 
 		private IConnectableObservable<ColoredFrame> _framesColoredGray2;
 
@@ -113,11 +113,10 @@ namespace LibDmd.Input.PinballFX
 				_framesColoredGray2 = Observable.Interval(TimeSpan.FromMilliseconds(1000d / FramesPerSecond))
 					.Select(x => CaptureWindow())
 					.Where(bmp => bmp != null)
-					.Select(bmp => gridProcessor.Process(bmp))
 					.Select(bmp => TransformationUtil.Transform(bmp, 128, 32, ResizeMode.Stretch, false, false))
 					.Select(bmp => {
 						double hue;
-						var frame = ImageUtil.ConvertToGray2(bmp, 3, out hue);
+						var frame = ImageUtil.ConvertToGray2(bmp, 0.025, 0.3, out hue);
 						if (palette == null || Math.Abs(hue - lastHue) > 0.01) {
 							byte r, g, b;
 							ColorUtil.HslToRgb(hue, 1, 0.5, out r, out g, out b);

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ You should see a test image on your DMD as well as on a virtual DMD.
 
 1. Enable cabinet options in Pinball FX2
 2. Resize the DMD to:
-   - Width: `1040`
-   - Height: `272`
+   - Width: `520`
+   - Height: `136`
 3. Move the DMD to somewhere hidden like off-screen or behind the playfield
    (usually at `0`/`0`).
 4. Open a command prompt ([Windows]+[R], `cmd`, [enter])


### PR DESCRIPTION
This implements the changes discussed in #205. This results in really crisp output for FX3.  Unfortunately I don't have FX2 and it doesn't seem to be available for download anymore.  It would be really nice if someone could test it out and LMK if this is a good change for FX2 or if I should refactor to make these changes only apply to FX3.