### PR TITLE
Add client/server mode for pushing frames over the network.

### DIFF
--- a/Console/Common/BaseCommand.cs
+++ b/Console/Common/BaseCommand.cs
@@ -103,7 +103,7 @@ namespace DmdExt.Common
 
 			if (config.NetworkStream.Enabled) {
 				try {
-					renderers.Add(new NetworkStream(new Uri(config.NetworkStream.Url)));
+					renderers.Add(NetworkStream.GetInstance(new Uri(config.NetworkStream.Url)));
 					Logger.Info("Added websocket client renderer.");
 				} catch (Exception e) {
 					Logger.Warn("Network stream disabled: {0}", e.Message);

--- a/Console/Common/BaseCommand.cs
+++ b/Console/Common/BaseCommand.cs
@@ -7,6 +7,7 @@ using LibDmd;
 using LibDmd.Common;
 using LibDmd.DmdDevice;
 using LibDmd.Output;
+using LibDmd.Output.Network;
 using LibDmd.Output.Pin2Dmd;
 using LibDmd.Output.PinDmd1;
 using LibDmd.Output.PinDmd2;
@@ -98,6 +99,15 @@ namespace DmdExt.Common
 			if (config.VirtualAlphaNumericDisplay.Enabled) {
 				renderers.Add(VirtualAlphanumericDestination.GetInstance(CurrentDispatcher, config.VirtualAlphaNumericDisplay.Style, config as Configuration));
 				Logger.Info("Added virtual Alphanumeric renderer.");
+			}
+
+			if (config.NetworkStream.Enabled) {
+				try {
+					renderers.Add(new NetworkStream(new Uri(config.NetworkStream.Url)));
+					Logger.Info("Added websocket client renderer.");
+				} catch (Exception e) {
+					Logger.Warn("Network stream disabled: {0}", e.Message);
+				}
 			}
 
 			if (renderers.Count == 0) {

--- a/Console/Common/BaseCommand.cs
+++ b/Console/Common/BaseCommand.cs
@@ -23,14 +23,17 @@ namespace DmdExt.Common
 	{
 		protected static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-		private readonly RenderGraphCollection _graphs = new RenderGraphCollection();
+		private RenderGraphCollection _graphs;
 		private IConfiguration _config;
 
 		protected abstract void CreateRenderGraphs(RenderGraphCollection graphs);
 
 		public RenderGraphCollection GetRenderGraphs()
 		{
-			CreateRenderGraphs(_graphs);
+			if (_graphs == null) {
+				_graphs = new RenderGraphCollection();
+				CreateRenderGraphs(_graphs);
+			}
 			return _graphs;
 		}
 

--- a/Console/Common/BaseCommand.cs
+++ b/Console/Common/BaseCommand.cs
@@ -144,8 +144,6 @@ namespace DmdExt.Common
 			return dmd.VirtualControl;
 		}
 
-		
-
 		public void Execute(Action onCompleted, Action<Exception> onError)
 		{
 			GetRenderGraph().Init().StartRendering(onCompleted, onError);

--- a/Console/Common/BaseCommand.cs
+++ b/Console/Common/BaseCommand.cs
@@ -23,14 +23,15 @@ namespace DmdExt.Common
 	{
 		protected static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-		private IRenderer _graph;
+		private readonly RenderGraphCollection _graphs = new RenderGraphCollection();
 		private IConfiguration _config;
 
-		protected abstract IRenderer CreateRenderGraph();
+		protected abstract void CreateRenderGraphs(RenderGraphCollection graphs);
 
-		public IRenderer GetRenderGraph()
+		public RenderGraphCollection GetRenderGraphs()
 		{
-			return _graph ?? (_graph = CreateRenderGraph());
+			CreateRenderGraphs(_graphs);
+			return _graphs;
 		}
 
 		protected List<IDestination> GetRenderers(IConfiguration config)
@@ -146,15 +147,15 @@ namespace DmdExt.Common
 
 		public void Execute(Action onCompleted, Action<Exception> onError)
 		{
-			GetRenderGraph().Init().StartRendering(onCompleted, onError);
+			GetRenderGraphs().Init().StartRendering(onCompleted, onError);
 		}
 
 		public void Dispose()
 		{
 			if (_config == null || !_config.Global.NoClear) {
-				_graph?.ClearDisplay();
+				_graphs?.ClearDisplay();
 			}
-			_graph?.Dispose();
+			_graphs?.Dispose();
 		}
 	}
 

--- a/Console/Common/BaseOptions.cs
+++ b/Console/Common/BaseOptions.cs
@@ -10,7 +10,7 @@ namespace DmdExt.Common
 {
 	internal abstract class BaseOptions : IConfiguration
 	{
-		[Option('d', "destination", HelpText = "The destination where the DMD data is sent to. One of: [ auto, pindmdv1, pindmdv2, pindmdv3, pin2dmd, virtual, alphanumeric ]. Default: \"auto\", which outputs to all available devices.")]
+		[Option('d', "destination", HelpText = "The destination where the DMD data is sent to. One of: [ auto, pindmdv1, pindmdv2, pindmdv3, pin2dmd, virtual, alphanumeric, network ]. Default: \"auto\", which outputs to all available devices.")]
 		public DestinationType Destination { get; set; } = DestinationType.Auto;
 
 		[Option('r', "resize", HelpText = "How the source image is resized. One of: [ stretch, fill, fit ]. Default: \"stretch\".")]
@@ -64,6 +64,10 @@ namespace DmdExt.Common
 		[Option("color-matrix", HelpText = "Color matrix to use for Pixelcade displays. Default: RBG.")]
 		public ColorMatrix ColorMatrix { get; set; } = ColorMatrix.Rbg;
 
+		[Option("url", HelpText = "Websocket URL for streaming via network. Default: ws://localhost/server")]
+		public string WebsocketUrl { get; set; } = null;
+
+
 		public IGlobalConfig Global { get; }
 		public IVirtualDmdConfig VirtualDmd { get; }
 		public IVirtualAlphaNumericDisplayConfig VirtualAlphaNumericDisplay { get; }
@@ -77,6 +81,7 @@ namespace DmdExt.Common
 		public IBitmapConfig Bitmap { get; }
 		public IVpdbConfig VpdbStream { get; }
 		public IBrowserConfig BrowserStream { get; }
+		public INetworkConfig NetworkStream { get; }
 		public IPinUpConfig PinUp { get; }
 
 		protected BaseOptions()
@@ -94,12 +99,13 @@ namespace DmdExt.Common
 			Bitmap = new BitmapOptions(this);
 			VpdbStream = new VpdbOptions();
 			BrowserStream = new BrowserOptions();
+			NetworkStream = new NetworkOptions(this);
 			PinUp = new PinUpOptions(this);
 		}
 
 		public enum DestinationType
 		{
-			Auto, PinDMDv1, PinDMDv2, PinDMDv3, PIN2DMD, PIXELCADE, Virtual, AlphaNumeric
+			Auto, PinDMDv1, PinDMDv2, PinDMDv3, PIN2DMD, PIXELCADE, Virtual, AlphaNumeric, Network
 		}
 
 		public void Validate()
@@ -286,6 +292,19 @@ namespace DmdExt.Common
 	{
 		public bool Enabled => false;
 		public int Port => 0;
+	}
+	
+	internal class NetworkOptions : INetworkConfig
+	{
+		private readonly BaseOptions _options;
+
+		public NetworkOptions(BaseOptions options)
+		{
+			_options = options;
+		}
+
+		public bool Enabled => _options.Destination == BaseOptions.DestinationType.Network;
+		public string Url => _options.WebsocketUrl;
 	}
 
 	internal class PinUpOptions : IPinUpConfig

--- a/Console/Common/Options.cs
+++ b/Console/Common/Options.cs
@@ -51,7 +51,7 @@ namespace DmdExt.Common
 				case "test":
 					return AutoBuild(Test, "dmdext test [--destination=<destination>]", Test.LastParserState);
 				case "server":
-					return AutoBuild(Test, "dmdext server [--host=<host>] [--port=<port>]", Server.LastParserState);
+					return AutoBuild(Test, "dmdext server [--ip=<ip address>] [--port=<port>] [--path=<path>]", Server.LastParserState);
 				default:
 					return AutoBuild(this, "dmdext <command> [<options>]", null, false);
 			}

--- a/Console/Common/Options.cs
+++ b/Console/Common/Options.cs
@@ -5,6 +5,7 @@ using CommandLine;
 using CommandLine.Text;
 using DmdExt.Mirror;
 using DmdExt.Play;
+using DmdExt.Server;
 using DmdExt.Test;
 
 namespace DmdExt.Common
@@ -20,11 +21,15 @@ namespace DmdExt.Common
 		[VerbOption("test", HelpText = "Displays a test image on all available devices.")]
 		public TestOptions Test { get; set; }
 
+		[VerbOption("server", HelpText = "Starts a websocket server to receive frames on.")]
+		public ServerOptions Server { get; set; }
+
 		public Options()
 		{
 			Mirror = new MirrorOptions();
 			Play = new PlayOptions();
 			Test = new TestOptions();
+			Server = new ServerOptions();
 		}
 
 		public void Validate()
@@ -32,6 +37,7 @@ namespace DmdExt.Common
 			Mirror.Validate();
 			Play.Validate();
 			Test.Validate();
+			Server.Validate();
 		}
 
 		[HelpVerbOption]
@@ -44,6 +50,8 @@ namespace DmdExt.Common
 					return AutoBuild(Play, "dmdext play --file=<image path> [--destination=<destination>]", Play.LastParserState);
 				case "test":
 					return AutoBuild(Test, "dmdext test [--destination=<destination>]", Test.LastParserState);
+				case "server":
+					return AutoBuild(Test, "dmdext server [--host=<host>] [--port=<port>]", Server.LastParserState);
 				default:
 					return AutoBuild(this, "dmdext <command> [<options>]", null, false);
 			}

--- a/Console/Console.csproj
+++ b/Console/Console.csproj
@@ -137,6 +137,8 @@
     <Compile Include="Play\PlayCommand.cs" />
     <Compile Include="Play\PlayOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Server\ServerCommand.cs" />
+    <Compile Include="Server\ServerOptions.cs" />
     <Compile Include="Test\TestCommand.cs" />
     <Compile Include="Test\TestOptions.cs" />
   </ItemGroup>

--- a/Console/DmdExt.cs
+++ b/Console/DmdExt.cs
@@ -10,6 +10,7 @@ using System.Windows;
 using DmdExt.Common;
 using DmdExt.Mirror;
 using DmdExt.Play;
+using DmdExt.Server;
 using DmdExt.Test;
 using LibDmd;
 using LibDmd.Common;
@@ -125,6 +126,10 @@ namespace DmdExt
 
 					case "test":
 						_command = new TestCommand(config, (TestOptions)cmdLineOptions);
+						break;
+
+					case "server":
+						_command = new ServerCommand(config, (ServerOptions)cmdLineOptions);
 						break;
 
 					default:

--- a/Console/DmdExt.cs
+++ b/Console/DmdExt.cs
@@ -131,15 +131,15 @@ namespace DmdExt
 						throw new ArgumentOutOfRangeException();
 				}
 
-				var renderer = _command.GetRenderGraph();
+				var renderGraphs = _command.GetRenderGraphs();
 
 				if (config.Bitmap.Enabled) {
-					(renderer as RenderGraph)?.Destinations.Add(new BitmapOutput(config.Bitmap.Path));
+					renderGraphs.AddDestination(new BitmapOutput(config.Bitmap.Path));
 				}
 
 				if (config.PinUp.Enabled) {
 					try {
-						(renderer as RenderGraph)?.Destinations.Add(new PinUpOutput(config.PinUp.GameName));
+						renderGraphs.AddDestination(new PinUpOutput(config.PinUp.GameName));
 
 					} catch (Exception e) {
 						Logger.Warn("Error opening PinUP output: {0}", e.Message);

--- a/Console/Mirror/MirrorCommand.cs
+++ b/Console/Mirror/MirrorCommand.cs
@@ -23,7 +23,7 @@ namespace DmdExt.Mirror
 			_options = options;
 		}
 
-		protected override IRenderer CreateRenderGraph()
+		protected override void CreateRenderGraphs(RenderGraphCollection graphs)
 		{
 			// create graph with renderers
 			_graph = new RenderGraph {
@@ -88,7 +88,7 @@ namespace DmdExt.Mirror
 				default:
 					throw new ArgumentOutOfRangeException();
 			}
-			return _graph;
+			graphs.Add(_graph);
 		}
 	}
 }

--- a/Console/Play/PlayCommand.cs
+++ b/Console/Play/PlayCommand.cs
@@ -21,7 +21,7 @@ namespace DmdExt.Play
 			_options = options;
 		}
 
-		protected override IRenderer CreateRenderGraph()
+		protected override void CreateRenderGraphs(RenderGraphCollection graphs)
 		{
 			// define source
 			object source;
@@ -50,13 +50,14 @@ namespace DmdExt.Play
 			var frameSource = source as ISource;
 			if (frameSource != null) {
 				// chain them up
-				return new RenderGraph {
+				graphs.Add(new RenderGraph {
 					Source = frameSource,
 					Destinations = renderers,
 					Resize = _config.Global.Resize,
 					FlipHorizontally = _config.Global.FlipHorizontally,
 					FlipVertically = _config.Global.FlipVertically
-				};
+				});
+				return;
 			}
 
 			// not an ISource, so it must be a IRawSource.
@@ -71,7 +72,7 @@ namespace DmdExt.Play
 			if (rawOutput == null) {
 				throw new NoRawDestinationException("No device supporting raw data available.");
 			}
-			return new RawRenderer(rawSource, rawOutput);
+			graphs.Add(new RawRenderer(rawSource, rawOutput));
 		}
 	}
 

--- a/Console/Server/README.md
+++ b/Console/Server/README.md
@@ -1,0 +1,56 @@
+# Network Streaming
+
+DMD Extensions allow receiving frames through the network. Both ends are 
+implemented, i.e. you can receive and send frames.
+
+This can be useful if you want to test the DMD but your physical display
+is connected to a different machine, or if you have a display that is already
+driven by a network daemon and you want it to receive data from dmdext.
+
+The frames are sent in binary data through a WebSocket and are thus somewhat
+effecient.
+
+## Server
+
+*Run this where your physical display is connected.*
+
+The console application now has another mode, `server`. This spawns a web 
+server and listens for incoming frames. The other options are the same, i.e.
+you can pass it the usual destination you want the server to output frames
+to.
+
+For example, with a PinDMD3, you would run the server like so:
+
+```
+dmdext server -d pindmdv3 --ip=127.0.0.1 --port=80 --path=/dmd
+```
+
+Now you have an open WebSocket at `ws://127.0.0.1/dmd` that listens to incoming
+frames.
+
+## Client
+
+*Run this where your game is running.*
+
+Dmdext now has another destination called `network` (or `[networkstream]` in
+DmdDevice.ini). Enabling it will send the frames of your game to the given
+WebSocket.
+
+For example, if you want to send the DMD of Pinball FX3 to the server you've 
+started above, you would run dmdext like this:
+
+```
+dmdext mirror -s pinballfx3 -d network --url=ws://127.0.0.1/dmd
+```
+
+Or, if you want to use it with VPM, add this to your DmdDevice.ini:
+
+```ini
+[networkstream]
+; if enabled, stream to your DMD connected to another computer
+enabled = true
+url = ws://127.0.0.1/dmd
+```
+
+Now, the display connected to where your server is running will render frames
+from where you're playing!

--- a/Console/Server/ServerCommand.cs
+++ b/Console/Server/ServerCommand.cs
@@ -21,9 +21,8 @@ namespace DmdExt.Server
 			_serverOptions = serverOptions;
 		}
 
-		protected override IRenderer CreateRenderGraph()
+		protected override void CreateRenderGraphs(RenderGraphCollection graphs)
 		{
-			return null;
 		}
 	}
 }

--- a/Console/Server/ServerCommand.cs
+++ b/Console/Server/ServerCommand.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using DmdExt.Common;
+using LibDmd;
+using LibDmd.DmdDevice;
+using LibDmd.Input;
+using LibDmd.Input.FileSystem;
+using LibDmd.Input.PinMame;
+using LibDmd.Output;
+
+namespace DmdExt.Server
+{
+	class ServerCommand : BaseCommand
+	{
+		private readonly IConfiguration _config;
+		private readonly ServerOptions _serverOptions;
+
+		public ServerCommand(IConfiguration config, ServerOptions serverOptions) {
+			_config = config;
+			_serverOptions = serverOptions;
+		}
+
+		protected override IRenderer CreateRenderGraph()
+		{
+			return null;
+		}
+	}
+}

--- a/Console/Server/ServerCommand.cs
+++ b/Console/Server/ServerCommand.cs
@@ -6,6 +6,7 @@ using LibDmd;
 using LibDmd.DmdDevice;
 using LibDmd.Input;
 using LibDmd.Input.FileSystem;
+using LibDmd.Input.Network;
 using LibDmd.Input.PinMame;
 using LibDmd.Output;
 
@@ -23,6 +24,9 @@ namespace DmdExt.Server
 
 		protected override void CreateRenderGraphs(RenderGraphCollection graphs)
 		{
+			var renderers = GetRenderers(_config);
+			var websocketServer = new WebsocketServer(_serverOptions.Ip, _serverOptions.Port, _serverOptions.Path);
+			websocketServer.SetupGraphs(graphs, renderers);
 		}
 	}
 }

--- a/Console/Server/ServerOptions.cs
+++ b/Console/Server/ServerOptions.cs
@@ -13,7 +13,7 @@ namespace DmdExt.Server
 		public int Port { get; set; } = 80;
 
 		[Option("path", HelpText = "WebSocket path. Default: /dmd")]
-		public string Path { get; set; } = "/server";
+		public string Path { get; set; } = "/dmd";
 
 		[ParserState]
 		public IParserState LastParserState { get; set; }

--- a/Console/Server/ServerOptions.cs
+++ b/Console/Server/ServerOptions.cs
@@ -1,0 +1,15 @@
+﻿using CommandLine;
+using DmdExt.Common;
+using LibDmd;
+
+namespace DmdExt.Server
+{
+	class ServerOptions : BaseOptions
+	{
+		[Option("host", HelpText = "WebSocket host to listen to. Default: ws://localhost")]
+		public string Host { get; set; } = "ws://localhost";
+
+		[Option("path", HelpText = "WebSocket path. Default: /dmd")]
+		public string Path { get; set; } = "/dmd";
+	}
+}

--- a/Console/Server/ServerOptions.cs
+++ b/Console/Server/ServerOptions.cs
@@ -6,10 +6,16 @@ namespace DmdExt.Server
 {
 	class ServerOptions : BaseOptions
 	{
-		[Option("host", HelpText = "WebSocket host to listen to. Default: ws://localhost")]
-		public string Host { get; set; } = "ws://localhost";
+		[Option("ip", HelpText = "IP address to listen to. Put 0.0.0.0 to listen to all interfaces. Default: 127.0.0.1")]
+		public string Ip { get; set; } = "127.0.0.1";
+		
+		[Option("port", HelpText = "WebSocket host to listen to. Default: 80")]
+		public int Port { get; set; } = 80;
 
 		[Option("path", HelpText = "WebSocket path. Default: /dmd")]
-		public string Path { get; set; } = "/dmd";
+		public string Path { get; set; } = "/server";
+
+		[ParserState]
+		public IParserState LastParserState { get; set; }
 	}
 }

--- a/Console/Test/TestCommand.cs
+++ b/Console/Test/TestCommand.cs
@@ -23,7 +23,7 @@ namespace DmdExt.Test
 			_testOptions = testOptions;
 		}
 
-		protected override IRenderer CreateRenderGraph()
+		protected override void CreateRenderGraphs(RenderGraphCollection graphs)
 		{
 			// define renderers
 			var renderers = GetRenderers(_config);
@@ -82,7 +82,7 @@ namespace DmdExt.Test
 				};
 			}
 
-			return _graph;
+			graphs.Add(_graph);
 		}
 	}
 }

--- a/Console/Test/TestOptions.cs
+++ b/Console/Test/TestOptions.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using CommandLine;
+﻿using CommandLine;
 using DmdExt.Common;
 using LibDmd;
 

--- a/LibDmd/Common/ColorUtil.cs
+++ b/LibDmd/Common/ColorUtil.cs
@@ -209,6 +209,15 @@ namespace LibDmd.Common
 			return (color.R << 16) + (color.G << 8) + color.B;
 		}
 
+		public static Color FromInt(int color) 
+		{
+			return Color.FromRgb(
+				(byte)(color >> 16), 
+				(byte)((color >> 8) & 0xff), 
+				(byte)(color & 0xff)
+			);
+		}
+
 		/// <summary>
 		/// Converts a palette to an array of single integers.
 		/// </summary>

--- a/LibDmd/DmdDevice/Configuration.cs
+++ b/LibDmd/DmdDevice/Configuration.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.NetworkInformation;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -13,7 +12,6 @@ using IniParser.Model;
 using LibDmd.Common;
 using LibDmd.Input;
 using LibDmd.Output.Virtual.AlphaNumeric;
-using MonoLibUsb;
 using NLog;
 using SkiaSharp;
 
@@ -106,6 +104,7 @@ namespace LibDmd.DmdDevice
 			Bitmap = new BitmapConfig(_data, this);
 			VpdbStream = new VpdbConfig(_data, this);
 			BrowserStream = new BrowserConfig(_data, this);
+			NetworkStream = new NetworkConfig(_data, this);
 			PinUp = new PinUpConfig(_data, this);
 
 			OnSave.Throttle(TimeSpan.FromMilliseconds(500)).Subscribe(_ => {
@@ -484,6 +483,18 @@ namespace LibDmd.DmdDevice
 		public bool Enabled => GetBoolean("enabled", false);
 		public int Port => GetInt("port", 9090);
 		public BrowserConfig(IniData data, Configuration parent) : base(data, parent)
+		{
+		}
+	}
+	
+	public class NetworkConfig : AbstractConfiguration, INetworkConfig
+	{
+		public override string Name { get; } = "networkstream";
+		public bool Enabled => GetBoolean("enabled", false);
+
+		public string Url => GetString("url", "ws://127.0.0.1/server");
+
+		public NetworkConfig(IniData data, Configuration parent) : base(data, parent)
 		{
 		}
 	}

--- a/LibDmd/DmdDevice/Configuration.cs
+++ b/LibDmd/DmdDevice/Configuration.cs
@@ -48,6 +48,7 @@ namespace LibDmd.DmdDevice
 		public GameConfig GameConfig { get; private set; }
 		public IVpdbConfig VpdbStream { get; }
 		public IBrowserConfig BrowserStream { get; }
+		public INetworkConfig NetworkStream { get; }
 		public IPinUpConfig PinUp { get; }
 
 		public void Validate()

--- a/LibDmd/DmdDevice/DmdDevice.cs
+++ b/LibDmd/DmdDevice/DmdDevice.cs
@@ -364,6 +364,9 @@ namespace LibDmd.DmdDevice
 			if (_config.BrowserStream.Enabled) {
 				renderers.Add(new BrowserStream(_config.BrowserStream.Port, _gameName));
 			}
+			if (_config.NetworkStream.Enabled) {
+				renderers.Add(new NetworkStream(new Uri(_config.NetworkStream.Url), _gameName));
+			}
 
 			if (renderers.Count == 0) {
 				Logger.Error("No renderers found, exiting.");

--- a/LibDmd/DmdDevice/DmdDevice.cs
+++ b/LibDmd/DmdDevice/DmdDevice.cs
@@ -365,7 +365,7 @@ namespace LibDmd.DmdDevice
 				renderers.Add(new BrowserStream(_config.BrowserStream.Port, _gameName));
 			}
 			if (_config.NetworkStream.Enabled) {
-				renderers.Add(new NetworkStream(new Uri(_config.NetworkStream.Url), _gameName));
+				renderers.Add(NetworkStream.GetInstance(new Uri(_config.NetworkStream.Url), _gameName));
 			}
 
 			if (renderers.Count == 0) {

--- a/LibDmd/DmdDevice/IConfiguration.cs
+++ b/LibDmd/DmdDevice/IConfiguration.cs
@@ -19,6 +19,7 @@ namespace LibDmd.DmdDevice
 		IBitmapConfig Bitmap { get; }
 		IVpdbConfig VpdbStream { get; }
 		IBrowserConfig BrowserStream { get; }
+		INetworkConfig NetworkStream { get; }
 		IPinUpConfig PinUp { get; }
 		void Validate();
 	}
@@ -107,6 +108,12 @@ namespace LibDmd.DmdDevice
 	{
 		bool Enabled { get; }
 		int Port { get; }
+	}
+
+	public interface INetworkConfig
+	{
+		bool Enabled { get; }
+		string Url { get; }
 	}
 
 	public interface IVpdbConfig

--- a/LibDmd/Input/ISource.cs
+++ b/LibDmd/Input/ISource.cs
@@ -47,6 +47,11 @@ namespace LibDmd.Input
 	{
 		public int Width { get; set; }
 		public int Height { get; set; }
+
+		public Dimensions(int width, int height) {
+			Width = width;
+			Height = height;
+		}
 	}
 
 	public enum ResizeMode

--- a/LibDmd/Input/Network/WebsocketColoredGray2Source.cs
+++ b/LibDmd/Input/Network/WebsocketColoredGray2Source.cs
@@ -8,9 +8,9 @@ using System.Threading.Tasks;
 
 namespace LibDmd.Input.Network
 {
-	public class WebsocketGray2Source : AbstractSource, IGray2Source
+	public class WebsocketColoredGray2Source : AbstractSource, IColoredGray2Source
 	{
-		public override string Name => "Websocket 2-bit Source";
+		public override string Name => "Websocket Colored 2-bit Source";
 
 		IObservable<Unit> ISource.OnResume => _onResume;
 		IObservable<Unit> ISource.OnPause => _onPause;
@@ -18,11 +18,11 @@ namespace LibDmd.Input.Network
 		private readonly ISubject<Unit> _onResume = new Subject<Unit>();
 		private readonly ISubject<Unit> _onPause = new Subject<Unit>();
 
-		public readonly Subject<byte[]> FramesGray2 = new Subject<byte[]>();
+		public readonly Subject<ColoredFrame> FramesColoredGray2 = new Subject<ColoredFrame>();
 
-		public IObservable<byte[]> GetGray2Frames()
+		public IObservable<ColoredFrame> GetColoredGray2Frames()
 		{
-			return FramesGray2;
+			return FramesColoredGray2;
 		}
 	}
 }

--- a/LibDmd/Input/Network/WebsocketColoredGray4Source.cs
+++ b/LibDmd/Input/Network/WebsocketColoredGray4Source.cs
@@ -8,9 +8,9 @@ using System.Threading.Tasks;
 
 namespace LibDmd.Input.Network
 {
-	public class WebsocketGray2Source : AbstractSource, IGray2Source
+	public class WebsocketColoredGray4Source : AbstractSource, IColoredGray4Source
 	{
-		public override string Name => "Websocket 2-bit Source";
+		public override string Name => "Websocket Colored 4-bit Source";
 
 		IObservable<Unit> ISource.OnResume => _onResume;
 		IObservable<Unit> ISource.OnPause => _onPause;
@@ -18,11 +18,11 @@ namespace LibDmd.Input.Network
 		private readonly ISubject<Unit> _onResume = new Subject<Unit>();
 		private readonly ISubject<Unit> _onPause = new Subject<Unit>();
 
-		public readonly Subject<byte[]> FramesGray2 = new Subject<byte[]>();
+		public readonly Subject<ColoredFrame> FramesColoredGray4 = new Subject<ColoredFrame>();
 
-		public IObservable<byte[]> GetGray2Frames()
+		public IObservable<ColoredFrame> GetColoredGray4Frames()
 		{
-			return FramesGray2;
+			return FramesColoredGray4;
 		}
 	}
 }

--- a/LibDmd/Input/Network/WebsocketGray2Source.cs
+++ b/LibDmd/Input/Network/WebsocketGray2Source.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Subjects;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LibDmd.Input.Network
+{
+	public class WebsocketGray2Source : AbstractSource, IGray2Source
+	{
+		public override string Name => "Websocket 2-bit Source";
+
+		BehaviorSubject<Dimensions> ISource.Dimensions { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+		IObservable<Unit> ISource.OnResume => _onResume;
+		IObservable<Unit> ISource.OnPause => _onPause;
+
+		private readonly ISubject<Unit> _onResume = new Subject<Unit>();
+		private readonly ISubject<Unit> _onPause = new Subject<Unit>();
+
+		private readonly Subject<byte[]> _framesGray2 = new Subject<byte[]>();
+
+		public IObservable<byte[]> GetGray2Frames()
+		{
+			return _framesGray2;
+		}
+	}
+}

--- a/LibDmd/Input/Network/WebsocketGray2Source.cs
+++ b/LibDmd/Input/Network/WebsocketGray2Source.cs
@@ -12,8 +12,6 @@ namespace LibDmd.Input.Network
 	{
 		public override string Name => "Websocket 2-bit Source";
 
-		BehaviorSubject<Dimensions> ISource.Dimensions { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
 		IObservable<Unit> ISource.OnResume => _onResume;
 		IObservable<Unit> ISource.OnPause => _onPause;
 

--- a/LibDmd/Input/Network/WebsocketGray4Source .cs
+++ b/LibDmd/Input/Network/WebsocketGray4Source .cs
@@ -8,9 +8,9 @@ using System.Threading.Tasks;
 
 namespace LibDmd.Input.Network
 {
-	public class WebsocketGray2Source : AbstractSource, IGray2Source
+	public class WebsocketGray4Source : AbstractSource, IGray4Source
 	{
-		public override string Name => "Websocket 2-bit Source";
+		public override string Name => "Websocket 4-bit Source";
 
 		IObservable<Unit> ISource.OnResume => _onResume;
 		IObservable<Unit> ISource.OnPause => _onPause;
@@ -18,11 +18,11 @@ namespace LibDmd.Input.Network
 		private readonly ISubject<Unit> _onResume = new Subject<Unit>();
 		private readonly ISubject<Unit> _onPause = new Subject<Unit>();
 
-		public readonly Subject<byte[]> FramesGray2 = new Subject<byte[]>();
+		public readonly Subject<byte[]> FramesGray4 = new Subject<byte[]>();
 
-		public IObservable<byte[]> GetGray2Frames()
+		public IObservable<byte[]> GetGray4Frames()
 		{
-			return FramesGray2;
+			return FramesGray4;
 		}
 	}
 }

--- a/LibDmd/Input/Network/WebsocketRgb24Source.cs
+++ b/LibDmd/Input/Network/WebsocketRgb24Source.cs
@@ -8,9 +8,9 @@ using System.Threading.Tasks;
 
 namespace LibDmd.Input.Network
 {
-	public class WebsocketGray2Source : AbstractSource, IGray2Source
+	public class WebsocketRgb24Source : AbstractSource, IRgb24Source
 	{
-		public override string Name => "Websocket 2-bit Source";
+		public override string Name => "Websocket 24-bit RGB Source";
 
 		IObservable<Unit> ISource.OnResume => _onResume;
 		IObservable<Unit> ISource.OnPause => _onPause;
@@ -18,11 +18,11 @@ namespace LibDmd.Input.Network
 		private readonly ISubject<Unit> _onResume = new Subject<Unit>();
 		private readonly ISubject<Unit> _onPause = new Subject<Unit>();
 
-		public readonly Subject<byte[]> FramesGray2 = new Subject<byte[]>();
+		public readonly Subject<byte[]> FramesRgb24 = new Subject<byte[]>();
 
-		public IObservable<byte[]> GetGray2Frames()
+		public IObservable<byte[]> GetRgb24Frames()
 		{
-			return FramesGray2;
+			return FramesRgb24;
 		}
 	}
 }

--- a/LibDmd/Input/Network/WebsocketServer.cs
+++ b/LibDmd/Input/Network/WebsocketServer.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Media;
 using LibDmd.Output;
+using LibDmd.Output.Network;
 using NLog;
 using WebSocketSharp;
 using WebSocketSharp.Server;
@@ -13,7 +15,7 @@ using HttpStatusCode = WebSocketSharp.Net.HttpStatusCode;
 
 namespace LibDmd.Input.Network
 {
-	public class WebsocketServer
+	public class WebsocketServer : ISocketAction
 	{
 		internal WebsocketGray2Source Gray2Source = new WebsocketGray2Source();
 
@@ -68,11 +70,37 @@ namespace LibDmd.Input.Network
 			_sockets.Remove(socket);
 			Logger.Debug("Socket {0} closed", socket.ID);
 		}
+
+		public void OnColor(Color color)
+		{
+			Logger.Info("OnColor {0}", color);
+		}
+
+		public void OnPalette(Color[] palette)
+		{
+			Logger.Info("OnPalette {0}", palette);
+		}
+
+		public void OnClearColor()
+		{
+			Logger.Info("OnClearColor");
+		}
+
+		public void OnClearPalette()
+		{
+			Logger.Info("OnClearPalette");
+		}
+
+		public void OnDimensions(int width, int height)
+		{
+			Logger.Info("OnDimensions: {0}x{1}", width, height);
+		}
 	}
 
-	public class DmdSocket : WebSocketBehavior {
-		
+	public class DmdSocket : WebSocketBehavior
+	{
 		private readonly WebsocketServer _src;
+		private readonly WebsocketSerializer _serializer = new WebsocketSerializer();
 
 		private static readonly NLog.Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -82,7 +110,7 @@ namespace LibDmd.Input.Network
 	
 		protected override void OnMessage(MessageEventArgs e)
 		{
-			Logger.Debug("Message! {0}", e);
+			_serializer.Unserialize(e.RawData, _src);
 		}
 
 		protected override void OnClose(CloseEventArgs e)

--- a/LibDmd/Input/Network/WebsocketServer.cs
+++ b/LibDmd/Input/Network/WebsocketServer.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NLog;
+using WebSocketSharp;
+using WebSocketSharp.Server;
+
+namespace LibDmd.Input.Network
+{
+	public class WebsocketServer
+	{
+		private readonly WebSocketServer _server;
+		private readonly List<DmdSocket> _sockets = new List<DmdSocket>();
+
+		private static readonly NLog.Logger Logger = LogManager.GetCurrentClassLogger();
+
+		public WebsocketServer(string host, string path) {
+			_server = new WebSocketServer(host);
+			_server.AddWebSocketService(path, () => {
+				var socket = new DmdSocket(this);
+				_sockets.Add(socket);
+				return socket;
+			});
+			_server.Start();
+			if (_server.IsListening) {
+				Logger.Info("Server listening at {0}{1}...", host, path);
+			}
+		}
+		
+		public void Dispose()
+		{
+			_server.Stop();
+		}
+
+		internal void Closed(DmdSocket socket)
+		{
+			_sockets.Remove(socket);
+			Logger.Debug("Socket {0} closed", socket.ID);
+		}
+	}
+
+	public class DmdSocket : WebSocketBehavior {
+		
+		private readonly WebsocketServer _src;
+
+		private static readonly NLog.Logger Logger = LogManager.GetCurrentClassLogger();
+
+		public DmdSocket(WebsocketServer src) {
+			_src = src;
+		}
+	
+		protected override void OnMessage(MessageEventArgs e)
+		{
+			
+		}
+
+		protected override void OnClose(CloseEventArgs e)
+		{
+			_src.Closed(this);
+		}
+
+		protected override void OnError(ErrorEventArgs e)
+		{
+			Logger.Error(e.Exception, "Websock error: {0}", e.Message);
+			_src.Closed(this);
+		}
+
+		protected override void OnOpen()
+		{
+			Logger.Info("Websocket opened.");
+		}
+	}
+}

--- a/LibDmd/Input/Network/WebsocketServer.cs
+++ b/LibDmd/Input/Network/WebsocketServer.cs
@@ -82,7 +82,7 @@ namespace LibDmd.Input.Network
 	
 		protected override void OnMessage(MessageEventArgs e)
 		{
-			
+			Logger.Debug("Message! {0}", e);
 		}
 
 		protected override void OnClose(CloseEventArgs e)

--- a/LibDmd/Input/Network/WebsocketServer.cs
+++ b/LibDmd/Input/Network/WebsocketServer.cs
@@ -58,6 +58,7 @@ namespace LibDmd.Input.Network
 
 		public void SetupGraphs(RenderGraphCollection graphs, List<IDestination> renderers)
 		{
+			_graphs = graphs;
 			graphs.Add(new RenderGraph {
 				Name = "2-bit Websocket Graph",
 				Source = Gray2Source,
@@ -93,7 +94,7 @@ namespace LibDmd.Input.Network
 		internal void Closed(DmdSocket socket)
 		{
 			_sockets.Remove(socket);
-			Logger.Debug("Socket {0} closed", socket.ID);
+			Logger.Debug("WebSocket {0} closed", socket.ID);
 		}
 
 		public void OnColor(Color color) => _graphs.SetColor(color);
@@ -153,7 +154,7 @@ namespace LibDmd.Input.Network
 
 		protected override void OnOpen()
 		{
-			Logger.Info("Websocket opened.");
+			Logger.Debug("New WebSocket client {0}", ID);
 		}
 	}
 }

--- a/LibDmd/Input/Network/WebsocketServer.cs
+++ b/LibDmd/Input/Network/WebsocketServer.cs
@@ -18,6 +18,10 @@ namespace LibDmd.Input.Network
 	public class WebsocketServer : ISocketAction
 	{
 		internal WebsocketGray2Source Gray2Source = new WebsocketGray2Source();
+		internal WebsocketGray4Source Gray4Source = new WebsocketGray4Source();
+		internal WebsocketColoredGray2Source ColoredGray2Source = new WebsocketColoredGray2Source();
+		internal WebsocketColoredGray4Source ColoredGray4Source = new WebsocketColoredGray4Source();
+		internal WebsocketRgb24Source Rgb24Source = new WebsocketRgb24Source();
 
 		private readonly HttpServer _server;
 		private readonly List<DmdSocket> _sockets = new List<DmdSocket>();
@@ -58,6 +62,26 @@ namespace LibDmd.Input.Network
 				Source = Gray2Source,
 				Destinations = renderers,
 			});
+			graphs.Add(new RenderGraph {
+				Name = "4-bit Websocket Graph",
+				Source = Gray4Source,
+				Destinations = renderers,
+			});
+			graphs.Add(new RenderGraph {
+				Name = "Colored 2-bit Websocket Graph",
+				Source = ColoredGray2Source,
+				Destinations = renderers,
+			});
+			graphs.Add(new RenderGraph {
+				Name = "Colored 4-bit Websocket Graph",
+				Source = ColoredGray4Source,
+				Destinations = renderers,
+			});
+			graphs.Add(new RenderGraph {
+				Name = "24-bit RGB Websocket Graph",
+				Source = Rgb24Source,
+				Destinations = renderers,
+			});
 		}
 
 		public void Dispose()
@@ -95,6 +119,24 @@ namespace LibDmd.Input.Network
 		{
 			Logger.Info("OnDimensions: {0}x{1}", width, height);
 		}
+
+		public void OnGameName(string gameName)
+		{
+			Logger.Info("OnGameName: {0}", gameName);
+		}
+
+		public void OnRgb24(uint timestamp, byte[] frame) => Rgb24Source.FramesRgb24.OnNext(frame);
+
+		public void OnColoredGray4(uint timestamp, Color[] palette, byte[][] planes)
+			=> ColoredGray4Source.FramesColoredGray4.OnNext(new ColoredFrame(planes, palette));
+
+		public void OnColoredGray2(uint timestamp, Color[] palette, byte[][] planes)
+			=> ColoredGray2Source.FramesColoredGray2.OnNext(new ColoredFrame(planes, palette));
+
+
+		public void OnGray4(uint timestamp, byte[] frame) => Gray4Source.FramesGray4.OnNext(frame);
+
+		public void OnGray2(uint timestamp, byte[] frame) => Gray2Source.FramesGray2.OnNext(frame);
 	}
 
 	public class DmdSocket : WebSocketBehavior

--- a/LibDmd/Input/Network/WebsocketServer.cs
+++ b/LibDmd/Input/Network/WebsocketServer.cs
@@ -25,6 +25,7 @@ namespace LibDmd.Input.Network
 
 		private readonly HttpServer _server;
 		private readonly List<DmdSocket> _sockets = new List<DmdSocket>();
+		private RenderGraphCollection _graphs;
 
 		private static readonly NLog.Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -95,30 +96,15 @@ namespace LibDmd.Input.Network
 			Logger.Debug("Socket {0} closed", socket.ID);
 		}
 
-		public void OnColor(Color color)
-		{
-			Logger.Info("OnColor {0}", color);
-		}
+		public void OnColor(Color color) => _graphs.SetColor(color);
 
-		public void OnPalette(Color[] palette)
-		{
-			Logger.Info("OnPalette {0}", palette);
-		}
+		public void OnPalette(Color[] palette) => _graphs.SetPalette(palette, -1);
 
-		public void OnClearColor()
-		{
-			Logger.Info("OnClearColor");
-		}
+		public void OnClearColor() => _graphs.ClearColor();
 
-		public void OnClearPalette()
-		{
-			Logger.Info("OnClearPalette");
-		}
+		public void OnClearPalette() => _graphs.ClearPalette();
 
-		public void OnDimensions(int width, int height)
-		{
-			Logger.Info("OnDimensions: {0}x{1}", width, height);
-		}
+		public void OnDimensions(int width, int height) => Gray2Source.Dimensions.OnNext(new Dimensions(width, height));
 
 		public void OnGameName(string gameName)
 		{
@@ -132,7 +118,6 @@ namespace LibDmd.Input.Network
 
 		public void OnColoredGray2(uint timestamp, Color[] palette, byte[][] planes)
 			=> ColoredGray2Source.FramesColoredGray2.OnNext(new ColoredFrame(planes, palette));
-
 
 		public void OnGray4(uint timestamp, byte[] frame) => Gray4Source.FramesGray4.OnNext(frame);
 

--- a/LibDmd/Input/Network/WebsocketServer.cs
+++ b/LibDmd/Input/Network/WebsocketServer.cs
@@ -22,13 +22,13 @@ namespace LibDmd.Input.Network
 
 		private static readonly NLog.Logger Logger = LogManager.GetCurrentClassLogger();
 
-		private const string _html = "<!DOCTYPE html><html><head><title>DmdExt Websocket Server</title></head><body><center style=\"margin-top=50px\"><h1>DmdExt Websocket Server</h1><p>Nothing to see here. Send frames to {ws_url} and you'll see them on your display.</p></center></body></html>";
+		private const string Html = "<!DOCTYPE html><html><head><title>DmdExt Websocket Server</title></head><body><center style=\"margin-top=50px\"><h1>DmdExt Websocket Server</h1><p>Nothing to see here. Send frames to {ws_url} and you'll see them on your display.</p></center></body></html>";
 
 		public WebsocketServer(string ip, int port, string path) {
 			
 			Logger.Info("Starting server at http://{0}:{1}{2}...", ip, port, path);
 			_server = new HttpServer(IPAddress.Parse(ip), port);
-			var html = _html.Replace("{ws_url}", ip + path);
+			var html = Html.Replace("{ws_url}", ip + path);
 			_server.OnGet += (sender, e) => {
 				var res = e.Response;
 				var data = Encoding.UTF8.GetBytes(html);

--- a/LibDmd/LibDmd.csproj
+++ b/LibDmd/LibDmd.csproj
@@ -208,6 +208,8 @@
     <Compile Include="DmdDevice\IConfiguration.cs" />
     <Compile Include="Input\Network\WebsocketServer.cs" />
     <Compile Include="Input\Network\WebsocketGray2Source.cs" />
+    <Compile Include="Output\Network\NetworkStream.cs" />
+    <Compile Include="Output\Network\WebsocketSerializer.cs" />
     <Compile Include="Output\Pixelcade\Pixelcade.cs" />
     <Compile Include="Output\Virtual\AlphaNumeric\AlphaNumericLayerSetting.xaml.cs">
       <DependentUpon>AlphaNumericLayerSetting.xaml</DependentUpon>

--- a/LibDmd/LibDmd.csproj
+++ b/LibDmd/LibDmd.csproj
@@ -206,6 +206,10 @@
     <Compile Include="ColoredFrame.cs" />
     <Compile Include="Common\CultureUtil.cs" />
     <Compile Include="DmdDevice\IConfiguration.cs" />
+    <Compile Include="Input\Network\WebsocketColoredGray4Source.cs" />
+    <Compile Include="Input\Network\WebsocketColoredGray2Source.cs" />
+    <Compile Include="Input\Network\WebsocketGray4Source .cs" />
+    <Compile Include="Input\Network\WebsocketRgb24Source.cs" />
     <Compile Include="Input\Network\WebsocketServer.cs" />
     <Compile Include="Input\Network\WebsocketGray2Source.cs" />
     <Compile Include="Output\Network\NetworkStream.cs" />

--- a/LibDmd/LibDmd.csproj
+++ b/LibDmd/LibDmd.csproj
@@ -206,6 +206,8 @@
     <Compile Include="ColoredFrame.cs" />
     <Compile Include="Common\CultureUtil.cs" />
     <Compile Include="DmdDevice\IConfiguration.cs" />
+    <Compile Include="Input\Network\WebsocketServer.cs" />
+    <Compile Include="Input\Network\WebsocketGray2Source.cs" />
     <Compile Include="Output\Pixelcade\Pixelcade.cs" />
     <Compile Include="Output\Virtual\AlphaNumeric\AlphaNumericLayerSetting.xaml.cs">
       <DependentUpon>AlphaNumericLayerSetting.xaml</DependentUpon>

--- a/LibDmd/Output/FileOutput/BitmapOutput.cs
+++ b/LibDmd/Output/FileOutput/BitmapOutput.cs
@@ -34,10 +34,6 @@ namespace LibDmd.Output.FileOutput
 			}
 		}
 
-		public void Init()
-		{
-		}
-
 		/// <summary>
 		/// Renders an image to the display.
 		/// </summary>

--- a/LibDmd/Output/FileOutput/GifOutput.cs
+++ b/LibDmd/Output/FileOutput/GifOutput.cs
@@ -32,10 +32,6 @@ namespace LibDmd.Output.FileOutput
 			}
 		}
 
-		public void Init()
-		{
-		}
-
 		/// <summary>
 		/// Renders an image to the display.
 		/// </summary>

--- a/LibDmd/Output/IDestination.cs
+++ b/LibDmd/Output/IDestination.cs
@@ -24,12 +24,6 @@ namespace LibDmd.Output
 		bool IsAvailable { get; }
 
 		/// <summary>
-		/// Initializes the device. <see cref="IsAvailable"/> must be set
-		/// after running this.
-		/// </summary>
-		void Init();
-
-		/// <summary>
 		/// Clears the display.
 		/// </summary>
 		void ClearDisplay();

--- a/LibDmd/Output/Network/BrowserStream.cs
+++ b/LibDmd/Output/Network/BrowserStream.cs
@@ -109,12 +109,12 @@ namespace LibDmd.Output.Network
 
 		public void RenderColoredGray2(ColoredFrame frame)
 		{
-			_sockets.ForEach(s => s.SendColoredGray("coloredGray2", frame.Planes, frame.Palette));
+			_sockets.ForEach(s => s.SendColoredGray2(frame.Planes, frame.Palette));
 		}
 
 		public void RenderColoredGray4(ColoredFrame frame)
 		{
-			_sockets.ForEach(s => s.SendColoredGray("coloredGray4", frame.Planes, frame.Palette));
+			_sockets.ForEach(s => s.SendColoredGray4(frame.Planes, frame.Palette));
 		}
 
 		public void RenderRgb24(byte[] frame)
@@ -207,12 +207,20 @@ namespace LibDmd.Output.Network
 			Send(_serializer.SerializeGray(frame, bitlength));
 		}
 
-		public void SendColoredGray(string name, byte[][] planes, Color[] palette)
+		public void SendColoredGray2(byte[][] planes, Color[] palette)
 		{
 			if (planes.Length == 0) {
 				return;
 			}
-			Send(_serializer.SerializeColoredGray(name, planes, palette));
+			Send(_serializer.SerializeColoredGray2(planes, palette));
+		}
+
+		public void SendColoredGray4(byte[][] planes, Color[] palette)
+		{
+			if (planes.Length == 0) {
+				return;
+			}
+			Send(_serializer.SerializeColoredGray4(planes, palette));
 		}
 
 		public void SendRgb24(byte[] frame) => Send(_serializer.SerializeRgb24(frame));

--- a/LibDmd/Output/Network/BrowserStream.cs
+++ b/LibDmd/Output/Network/BrowserStream.cs
@@ -78,11 +78,6 @@ namespace LibDmd.Output.Network
 			}
 		}
 				
-		public void Init()
-		{
-			// nothing to init
-		}
-
 		public void Init(DmdSocket socket)
 		{
 			Logger.Debug("Init socket");

--- a/LibDmd/Output/Network/NetworkStream.cs
+++ b/LibDmd/Output/Network/NetworkStream.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Windows.Media;
+using NLog;
+using WebSocketSharp;
+
+namespace LibDmd.Output.Network
+{
+	public class NetworkStream : IGray2Destination, IGray4Destination, IColoredGray2Destination, IColoredGray4Destination, IResizableDestination
+	{
+		public string Name { get; } = "Network Stream";
+		public bool IsAvailable { get; private set; } = false;
+
+		private WebSocket _client;
+		private readonly Uri _uri;
+		private readonly WebsocketSerializer _serializer = new WebsocketSerializer();
+		private readonly string _gameName;
+
+		private Color _color = RenderGraph.DefaultColor;
+		private Color[] _palette;
+
+		private static readonly NLog.Logger Logger = LogManager.GetCurrentClassLogger();
+
+		public NetworkStream(Uri uri, string romName = null)
+		{
+			_uri = uri;
+			_gameName = romName;
+		}
+
+		public void Init()
+		{
+			_client = new WebSocket(_uri.ToString());
+			_client.OnMessage += OnMessage;
+			_client.OnError += OnError;
+			_client.OnOpen += OnOpen;
+			_client.Connect();
+		}
+
+		private void OnOpen(object sender, EventArgs e)
+		{
+			IsAvailable = true;
+			Logger.Info("Connected to Websocket at {0}", _uri.ToString());
+
+			if (_gameName != null) {
+				_client.Send(_serializer.SerializeGameName(_gameName));
+			}
+			_client.Send(_serializer.SerializeDimensions(_serializer.Width, _serializer.Height));
+			_client.Send(_serializer.SerializeColor(_color));
+			if (_palette != null) {
+				_client.Send(_serializer.SerializePalette(_palette));
+			}
+		}
+
+		private void OnMessage(object sender, MessageEventArgs e)
+		{
+			Logger.Info("Message from server: " + e.Data);
+		}
+
+		private void OnError(object sender, ErrorEventArgs e)
+		{
+			Logger.Error("Network stream disconnected: " + e.Message);
+			IsAvailable = false;
+		}
+
+		private void SendGray(byte[] frame, int bitlength)
+		{
+			if (frame.Length < _serializer.Width * _serializer.Height) {
+				Logger.Info("SendGray: invalid frame received frame.length={0} bitlength={1} width={2} height={3}", frame.Length, bitlength, _serializer.Width, _serializer.Height);
+				return;
+			}
+			_client?.Send(_serializer.SerializeGray(frame, bitlength));
+		}
+
+		private void SendColoredGray(string name, byte[][] planes, Color[] palette)
+		{
+			if (planes.Length == 0) {
+				return;
+			}
+			_client?.Send(_serializer.SerializeColoredGray(name, planes, palette));
+		}
+
+		public void RenderGray2(byte[] frame)
+		{
+			SendGray(frame, 2);
+		}
+
+		public void RenderGray4(byte[] frame)
+		{
+			SendGray(frame, 4);
+		}
+
+		public void RenderColoredGray2(ColoredFrame frame)
+		{
+			_client?.Send(_serializer.SerializeColoredGray("coloredGray2", frame.Planes, frame.Palette));
+		}
+
+		public void RenderColoredGray4(ColoredFrame frame)
+		{
+			_client?.Send(_serializer.SerializeColoredGray("coloredGray4", frame.Planes, frame.Palette));
+		}
+
+		public void RenderRgb24(byte[] frame)
+		{
+			_client?.Send(_serializer.SerializeRgb24(frame));
+		}
+
+		public void SetDimensions(int width, int height)
+		{
+			_client?.Send(_serializer.SerializeDimensions(width, height));
+		}
+
+		public void SetColor(Color color)
+		{
+			_color = color;
+			_client?.Send(_serializer.SerializeColor(color));
+		}
+
+		public void SetPalette(Color[] colors, int index = -1)
+		{
+			_palette = colors;
+			_client?.Send(_serializer.SerializePalette(colors));
+		}
+
+		public void ClearPalette()
+		{
+			_client?.Send(_serializer.SerializeClearPalette());
+		}
+
+		public void ClearColor()
+		{
+			_client?.Send(_serializer.SerializeClearColor());
+		}
+
+		public void ClearDisplay()
+		{
+			// ignore
+		}
+		
+		public void Dispose()
+		{
+			((IDisposable)_client)?.Dispose();
+		}
+
+	}
+
+}

--- a/LibDmd/Output/Network/NetworkStream.cs
+++ b/LibDmd/Output/Network/NetworkStream.cs
@@ -24,10 +24,12 @@ namespace LibDmd.Output.Network
 		{
 			_uri = uri;
 			_gameName = romName;
+			Init();
 		}
 
 		public void Init()
 		{
+			Logger.Info("Connecting to Websocket at {0}", _uri.ToString());
 			_client = new WebSocket(_uri.ToString());
 			_client.OnMessage += OnMessage;
 			_client.OnError += OnError;

--- a/LibDmd/Output/Network/NetworkStream.cs
+++ b/LibDmd/Output/Network/NetworkStream.cs
@@ -72,14 +72,6 @@ namespace LibDmd.Output.Network
 			_client?.Send(_serializer.SerializeGray(frame, bitlength));
 		}
 
-		private void SendColoredGray(string name, byte[][] planes, Color[] palette)
-		{
-			if (planes.Length == 0) {
-				return;
-			}
-			_client?.Send(_serializer.SerializeColoredGray(name, planes, palette));
-		}
-
 		public void RenderGray2(byte[] frame)
 		{
 			SendGray(frame, 2);
@@ -92,12 +84,12 @@ namespace LibDmd.Output.Network
 
 		public void RenderColoredGray2(ColoredFrame frame)
 		{
-			_client?.Send(_serializer.SerializeColoredGray("coloredGray2", frame.Planes, frame.Palette));
+			_client?.Send(_serializer.SerializeColoredGray2(frame.Planes, frame.Palette));
 		}
 
 		public void RenderColoredGray4(ColoredFrame frame)
 		{
-			_client?.Send(_serializer.SerializeColoredGray("coloredGray4", frame.Planes, frame.Palette));
+			_client?.Send(_serializer.SerializeColoredGray4(frame.Planes, frame.Palette));
 		}
 
 		public void RenderRgb24(byte[] frame)

--- a/LibDmd/Output/Network/VpdbStream.cs
+++ b/LibDmd/Output/Network/VpdbStream.cs
@@ -95,10 +95,6 @@ namespace LibDmd.Output.Network
 			});
 		}
 
-		public void Init()
-		{
-		}
-
 		public void SetDimensions(int width, int height)
 		{
 			_width = width;

--- a/LibDmd/Output/Network/WebsocketSerializer.cs
+++ b/LibDmd/Output/Network/WebsocketSerializer.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Windows.Media;
+using LibDmd.Common;
+using NLog;
+using WebSocketSharp;
+
+namespace LibDmd.Output.Network
+{
+	internal class WebsocketSerializer
+	{
+		public int Width = 128;
+		public int Height = 32;
+
+		private readonly long _startedAt = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+
+		private static readonly NLog.Logger Logger = LogManager.GetCurrentClassLogger();
+
+		public byte[] SerializeGray(byte[] frame, int bitlength)
+		{
+			var timestamp = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+			var data = Encoding.ASCII
+				.GetBytes("gray" + bitlength + "Planes")
+				.Concat(new byte[] { 0x0 })
+				.Concat(BitConverter.GetBytes((uint)(timestamp - _startedAt)))
+				.Concat(FrameUtil.Split(Width, Height, bitlength, frame).SelectMany(p => p));
+
+			return data.ToArray();
+		}
+
+		public byte[] SerializeColoredGray(string name, byte[][] planes, Color[] palette)
+		{
+			var timestamp = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+			var data = Encoding.ASCII
+				.GetBytes(name)
+				.Concat(new byte[] { 0x0 })
+				.Concat(BitConverter.GetBytes((uint)(timestamp - _startedAt)))
+				.Concat(BitConverter.GetBytes(palette.Length))
+				.Concat(ColorUtil.ToIntArray(palette).SelectMany(BitConverter.GetBytes))
+				.Concat(planes.SelectMany(p => p));
+			return data.ToArray();
+		}
+
+		public byte[] SerializeRgb24(byte[] frame)
+		{
+			var timestamp = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+			var data = Encoding.ASCII
+				.GetBytes("rgb24")
+				.Concat(new byte[] { 0x0 })
+				.Concat(BitConverter.GetBytes((uint)(timestamp - _startedAt)))
+				.Concat(frame);
+			return data.ToArray();
+		}
+
+		public byte[] SerializeGameName(string gameName)
+		{
+			var data = Encoding.ASCII
+				.GetBytes("gameName")
+				.Concat(new byte[] { 0x0 })
+				.Concat(Encoding.ASCII.GetBytes(gameName));
+			Logger.Info("Sent game name to socket.");
+			return data.ToArray();
+		}
+
+		public byte[] SerializeDimensions(int width, int height)
+		{
+			Width = width;
+			Height = height;
+			var data = Encoding.ASCII
+				.GetBytes("dimensions")
+				.Concat(new byte[] { 0x0 })
+				.Concat(BitConverter.GetBytes(width))
+				.Concat(BitConverter.GetBytes(height));
+			Logger.Info("Sent dimensions to socket {0}x{1}.", width, height);
+			return data.ToArray();
+		}
+
+		public byte[] SerializeColor(Color color)
+		{
+			var data = Encoding.ASCII
+				.GetBytes("color")
+				.Concat(new byte[] { 0x0 })
+				.Concat(BitConverter.GetBytes(ColorUtil.ToInt(color)));
+			return data.ToArray();
+		}
+
+		public byte[] SerializePalette(Color[] colors)
+		{
+			var data = Encoding.ASCII
+				.GetBytes("palette")
+				.Concat(new byte[] { 0x0 })
+				.Concat(BitConverter.GetBytes(colors.Length))
+				.Concat(ColorUtil.ToIntArray(colors).SelectMany(BitConverter.GetBytes));
+			return data.ToArray();
+		}
+
+		public byte[] SerializeClearColor()
+		{
+			var data = Encoding.ASCII
+				.GetBytes("clearColor")
+				.Concat(new byte[] { 0x0 });
+			return data.ToArray();
+		}
+
+		public byte[] SerializeClearPalette()
+		{
+			var data = Encoding.ASCII
+				.GetBytes("clearPalette")
+				.Concat(new byte[] { 0x0 });
+			return data.ToArray();
+		}
+	}
+}

--- a/LibDmd/Output/Network/WebsocketSerializer.cs
+++ b/LibDmd/Output/Network/WebsocketSerializer.cs
@@ -9,7 +9,6 @@ using WebSocketSharp;
 
 namespace LibDmd.Output.Network
 {
-
 	internal interface ISocketAction
 	{
 		void OnColor(Color color);
@@ -43,7 +42,6 @@ namespace LibDmd.Output.Network
 				var name = Encoding.ASCII.GetString(reader.ReadBytes(start - 1));
 				reader.BaseStream.Seek(1, SeekOrigin.Current);
 				
-				Logger.Debug("Unserialize {0}", name);
 				switch (name) {
 					case "color": {
 						action.OnColor(ColorUtil.FromInt(reader.ReadInt32()));

--- a/LibDmd/Output/PinUp/PinUpOutput.cs
+++ b/LibDmd/Output/PinUp/PinUpOutput.cs
@@ -93,14 +93,6 @@ namespace LibDmd.Output.PinUp
 			SetGameName(_pnt, _gameName.Length); // external PUP dll call
 		}
 
-		public void Init()
-		{
-			// throw new InvalidFolderException("iniiintiting");
-			if (this is IFixedSizeDestination) {
-				//SetDimensions(DmdWidth, DmdHeight);
-			}
-		}
-
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
 		//Render Bitmap gets called by dmdext console.  (pinball fx2/3 type support)

--- a/LibDmd/Output/Virtual/AlphaNumeric/VirtualAlphanumericDestination.cs
+++ b/LibDmd/Output/Virtual/AlphaNumeric/VirtualAlphanumericDestination.cs
@@ -44,11 +44,6 @@ namespace LibDmd.Output.Virtual.AlphaNumeric
 			return _instance ?? (_instance = new VirtualAlphanumericDestination(dispatcher, styleDef, config));
 		}
 
-		public void Init()
-		{
-			Logger.Info("{0} initialized.", Name);
-		}
-
 		public void RenderAlphaNumeric(AlphaNumericFrame frame)
 		{
 			if (_currentLayout == NumericalLayout.None || _currentLayout != frame.SegmentLayout) {

--- a/LibDmd/RenderGraphCollection.cs
+++ b/LibDmd/RenderGraphCollection.cs
@@ -124,6 +124,10 @@ namespace LibDmd
 			}
 		}
 
+		public void SetDimensions(Dimensions dim) {
+			_graphs.ForEach(graph => graph.Source.Dimensions.OnNext(dim));
+		}
+
 		public void Dispose()
 		{
 			if (_renderer != null) {

--- a/PinMameDevice/DmdDevice.ini
+++ b/PinMameDevice/DmdDevice.ini
@@ -50,11 +50,16 @@ delay = 25
 
 [pixelcade]
 ; if false, doesn't bother looking for a Pixelcade
-enabled = true
+enabled = false
 ; COM port, e.g. COM3
 port = 
 ; color matrix to use, either "rgb" or "rbg"
 matrix = rgb
+
+[networkstream]
+; if enabled, stream to your DMD connected to another computer
+enabled = false
+url = ws://127.0.0.1/dmd
 
 [browserstream]
 ; if enabled, stream to your browser in your LAN

--- a/PinMameDevice/README.md
+++ b/PinMameDevice/README.md
@@ -90,8 +90,8 @@ DMDDEV void Console_Input_Ptr(Console_Input_t ptr);
 
 ## Building
 
-Just load the parent solution into Visual Studio and you should be fine. Tested
-on VS2015 and VS2017.
+Just load the parent solution into Visual Studio and you should be fine. Set up
+for VS2019, but you should able to compile it with other versions as well.
 
 If you want the build process automatically copy `DmdDevice.dll` into your VPM
 folder, point the `VPM_HOME` environment variable to your VPM folder.

--- a/ProPinballBridge/ProPinballBridge.vcxproj
+++ b/ProPinballBridge/ProPinballBridge.vcxproj
@@ -31,48 +31,48 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>ProPinballBridge</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release - Coloring Disabled|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release - Coloring Disabled|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/ProPinballSlave/ProPinballSlave.vcxproj
+++ b/ProPinballSlave/ProPinballSlave.vcxproj
@@ -43,69 +43,69 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>ProPinballSlave</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release - Coloring Disabled|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release - Coloring Disabled|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release - Coloring Disabled|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ can set this up as you would for a PIN2DMD:
 
 ## Build Instructions
 
-1. Download and install [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/)
+1. Download and install [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/)
 2. The unmanaged exports library needs MS Build tools, which come with .NET 3.5. [Install Instructions](https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-10)
 4. *Optional:* If you want `DmdDevice.dll` copied to your VPM folder after build, point the `VPM_HOME` environment variable to your VPM installation folder.
 5. Clone the repo: `git clone https://github.com/freezy/dmd-extensions.git`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Currently supported displays:
   debugging.
 - **Alphanumeric Virtual**, a high-resolution virtual segmented display for 
   pre-DMD area games.
+- **Network**, use dmdext to send and receive data through the network.
 - You can also stream the DMD to a browser in your LAN, because, why not!
 
 ## Features
@@ -46,6 +47,8 @@ alpha-numeric displays:
 <image src="https://user-images.githubusercontent.com/70426/50459439-5f81bf00-096b-11e9-9f75-f70387f2c9cc.png" width="350"/>
 
 Documentation how to enable and customize this feature can be found [here](https://github.com/freezy/dmd-extensions/tree/master/LibDmd/Output/Virtual/AlphaNumeric).
+
+Since v1.8, DMD Extensions come with full network support. Documentation can be found [here](Console/Server)
 
 ## Install Instructions
 


### PR DESCRIPTION
We're re-using the same frame format as in the browser stream driver. More documentation can be found [here](https://github.com/freezy/dmd-extensions/tree/server-client/Console/Server).

This has two goals: Lay the foundation of a more comfortable Pixelcade setup, and make it easier to drive displays that are connected to a remote machine.

It's still experimental and not battle-tested at all. Specially error handling with the current [WebSocket dependency](https://github.com/sta/websocket-sharp) that isn't updated since 2016 is sub-optimal and might needs a rewrite.