### PR TITLE
Add basic support for Websocket connection retry

### DIFF
--- a/Console/Common/BaseCommand.cs
+++ b/Console/Common/BaseCommand.cs
@@ -103,7 +103,7 @@ namespace DmdExt.Common
 
 			if (config.NetworkStream.Enabled) {
 				try {
-					renderers.Add(NetworkStream.GetInstance(new Uri(config.NetworkStream.Url)));
+					renderers.Add(NetworkStream.GetInstance(config.NetworkStream));
 					Logger.Info("Added websocket client renderer.");
 				} catch (Exception e) {
 					Logger.Warn("Network stream disabled: {0}", e.Message);

--- a/Console/Common/BaseOptions.cs
+++ b/Console/Common/BaseOptions.cs
@@ -67,6 +67,10 @@ namespace DmdExt.Common
 		[Option("url", HelpText = "Websocket URL for streaming via network. Default: ws://localhost/server")]
 		public string WebsocketUrl { get; set; } = null;
 
+		[Option("retry", HelpText = "If set, retry connecting if the Websocket connection fails. Default: false" )]
+		public bool WebsocketRetry { get; set; } = false;
+		[Option("retry-interval", HelpText = "In seconds, interval between Websocket connection retry attempts. Default: 5 seconds")]
+		public int WebsocketRetryInterval { get; set; } = 5;
 
 		public IGlobalConfig Global { get; }
 		public IVirtualDmdConfig VirtualDmd { get; }
@@ -305,6 +309,8 @@ namespace DmdExt.Common
 
 		public bool Enabled => _options.Destination == BaseOptions.DestinationType.Network;
 		public string Url => _options.WebsocketUrl;
+		public bool Retry => _options.WebsocketRetry;
+		public int RetryInterval => _options.WebsocketRetryInterval;
 	}
 
 	internal class PinUpOptions : IPinUpConfig

--- a/LibDmd/DmdDevice/Configuration.cs
+++ b/LibDmd/DmdDevice/Configuration.cs
@@ -493,6 +493,8 @@ namespace LibDmd.DmdDevice
 		public bool Enabled => GetBoolean("enabled", false);
 
 		public string Url => GetString("url", "ws://127.0.0.1/server");
+		public bool Retry => GetBoolean("retry", false);
+		public int RetryInterval => GetInt("retry-interval", 5);
 
 		public NetworkConfig(IniData data, Configuration parent) : base(data, parent)
 		{

--- a/LibDmd/DmdDevice/DmdDevice.cs
+++ b/LibDmd/DmdDevice/DmdDevice.cs
@@ -375,7 +375,7 @@ namespace LibDmd.DmdDevice
 				renderers.Add(new BrowserStream(_config.BrowserStream.Port, _gameName));
 			}
 			if (_config.NetworkStream.Enabled) {
-				renderers.Add(NetworkStream.GetInstance(new Uri(_config.NetworkStream.Url), _gameName));
+				renderers.Add(NetworkStream.GetInstance(_config.NetworkStream, _gameName));
 			}
 
 			if (renderers.Count == 0) {

--- a/LibDmd/DmdDevice/IConfiguration.cs
+++ b/LibDmd/DmdDevice/IConfiguration.cs
@@ -114,6 +114,8 @@ namespace LibDmd.DmdDevice
 	{
 		bool Enabled { get; }
 		string Url { get; }
+		bool Retry { get; }
+		int RetryInterval { get; }
 	}
 
 	public interface IVpdbConfig

--- a/LibDmd/Output/Network/NetworkStream.cs
+++ b/LibDmd/Output/Network/NetworkStream.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Timers;
 using System.Windows.Media;
+using LibDmd.DmdDevice;
 using NLog;
 using WebSocketSharp;
 
@@ -12,6 +14,10 @@ namespace LibDmd.Output.Network
 
 		private WebSocket _client;
 		private Uri _uri;
+		private bool _retry;
+		private int _retryInterval;
+		private Timer _retryTimer;
+		private bool _disposed = false;
 		private string _gameName;
 		private readonly WebsocketSerializer _serializer = new WebsocketSerializer();
 
@@ -21,32 +27,45 @@ namespace LibDmd.Output.Network
 		private static NetworkStream _instance;
 		private static readonly NLog.Logger Logger = LogManager.GetCurrentClassLogger();
 
-		public static NetworkStream GetInstance(Uri uri, string romName = null) {
+		public static NetworkStream GetInstance(INetworkConfig config, string romName = null) {
 			if (_instance == null) {
 				_instance = new NetworkStream();
 			}
-			_instance.Init(uri, romName);
+			_instance.Init(config, romName);
 			return _instance;
 		}
 
-		public void Init(Uri uri, string romName = null)
+		public void Init(INetworkConfig config, string romName = null)
 		{
-			_uri = uri;
+			_uri = new Uri(config.Url);
+			_retry = config.Retry;
+			// Convert interval to ms, make 1s the shortest retry interval
+			_retryInterval = config.RetryInterval < 1 ? 1000 : config.RetryInterval * 1000;
 			_gameName = romName;
-			Logger.Info("Connecting to WebSocket at {0}", _uri.ToString());
+			Logger.Info("Attempting to connect to WebSocket at {0}", _uri.ToString());
 			_client = new WebSocket(_uri.ToString());
 			_client.Log.Level = WebSocketSharp.LogLevel.Fatal;
 			_client.OnMessage += OnMessage;
 			_client.OnError += OnError;
 			_client.OnOpen += OnOpen;
+			_client.OnClose += OnClose;
 			_client.Connect();
-			Logger.Info("Connected to Websocket at {0}", _uri.ToString());
+		}
+
+		private void OnReconnect(object source, ElapsedEventArgs e)
+		{
+			// No point in retrying a connection if we have been disposed since timer was started.
+			if (!_disposed)
+			{
+				Logger.Info("Retrying connection to WebSocket at {0}", _uri.ToString());
+				_client.Connect();
+			}
 		}
 
 		private void OnOpen(object sender, EventArgs e)
 		{
 			IsAvailable = true;
-			Logger.Info("Connected to Websocket at {0}", _uri.ToString());
+			Logger.Info("Connected to WebSocket at {0}", _uri.ToString());
 
 			if (_gameName != null) {
 				_client.Send(_serializer.SerializeGameName(_gameName));
@@ -67,6 +86,23 @@ namespace LibDmd.Output.Network
 		{
 			Logger.Error("Network stream disconnected: " + e.Message);
 			IsAvailable = false;
+		}
+
+		private void OnClose(object sender, EventArgs e)
+		{
+			Logger.Info("WebSocket connection was closed or could not be establised.");
+			IsAvailable = false;
+			if (!_disposed && _retry)
+			{
+				if (_retryTimer == null)
+				{
+					// Create a one-shot timer set to go off after the _retryInterval has passed.
+					_retryTimer = new Timer(_retryInterval);
+					_retryTimer.Elapsed += OnReconnect;
+					_retryTimer.AutoReset = false;
+				}
+				_retryTimer.Start();
+			}
 		}
 
 		private void SendGray(byte[] frame, int bitlength)
@@ -153,9 +189,11 @@ namespace LibDmd.Output.Network
 		{
 			// ignore
 		}
-		
+
 		public void Dispose()
 		{
+			_disposed = true;
+			_retryTimer?.Dispose();
 			((IDisposable)_client)?.Dispose();
 		}
 

--- a/PinMameDevice/DmdDevice.ini
+++ b/PinMameDevice/DmdDevice.ini
@@ -60,6 +60,10 @@ matrix = rgb
 ; if enabled, stream to your DMD connected to another computer
 enabled = false
 url = ws://127.0.0.1/dmd
+; if enabled, retry connecting if the connection fails, default is false
+retry = false
+; interval in seconds between retry attempts, default is 5
+retry-interval = 5
 
 [browserstream]
 ; if enabled, stream to your browser in your LAN


### PR DESCRIPTION
Found that if the WebSocket service side of this was not already started or had to be restarted during a run, the WebSocket client wouldn't recover so no DMD updates would be sent.

This change is one approach at allowing the connection to recover if the service is not already running when a game starts or gets restarted during the lifetime of a game run.

Tested using both the dmdext cli tool and via VPX game setup that uses the network streaming option.

Retry feature is disabled by default and when enabled, a retry interval of 5 seconds. The retry interval can be changed via another option to be more or less frequent, lowest interval is 1 second.