### PR TITLE
Fix missing Skia native lib

### DIFF
--- a/LibDmd/LibDmd.csproj
+++ b/LibDmd/LibDmd.csproj
@@ -355,6 +355,7 @@
     <EmbeddedResource Include="Output\Virtual\AlphaNumeric\numeric-thin\full.svg" />
     <EmbeddedResource Include="Costura64\ftd2xx.dll" />
     <EmbeddedResource Include="Costura32\libSkiaSharp.dll" />
+    <EmbeddedResource Include="Costura64\libSkiaSharp.dll" />
     <Content Include="FodyWeavers.xml">
       <SubType>Designer</SubType>
     </Content>


### PR DESCRIPTION
Fix missing native lib for x64 (see https://github.com/freezy/dmd-extensions/issues/212). The dll given to Costura is the one taken from the LibSkiaSharp nuget package (like for x86). Note that I only did limited testing on this PR. Please check before merging !
