### PR TITLE
Fix Crash when VPM sends data out of the palette range

### DIFF
--- a/LibDmd/Common/ColorUtil.cs
+++ b/LibDmd/Common/ColorUtil.cs
@@ -275,6 +275,7 @@ namespace LibDmd.Common
 				bpalvalues[i] = palette[i].B;
 			}
 
+			var maxPixel = (byte)(palette.Length - 1);
 			unsafe
 			{
 				fixed (byte* pFrame = frame, pcolorFrame = colorizedFrame)
@@ -284,6 +285,7 @@ namespace LibDmd.Common
 
 					for (; pFrameCur < pFEnd; pFrameCur++, pColorFrameCur += 3) {
 						var pixel = *pFrameCur;
+						if (pixel > maxPixel) pixel = maxPixel; // Avoid crash when VPinMame sends data out of the palette range
 						*pColorFrameCur = rpalvalues[pixel];
 						*(pColorFrameCur + 1) = gpalvalues[pixel];
 						*(pColorFrameCur + 2) = bpalvalues[pixel];


### PR DESCRIPTION
This is small fix for the crash reported here: https://www.vpforums.org/index.php?showtopic=45797

It is not really a Freezy's DMD bug, but more a VPinMame one, but Freezy's DMD should not crash even when fed with incorrect data (here, VPM sends out of palette data for Pirate of The Caraibs during extraball sequence, or for World Poker Tour).

Here is a crash report of such a situation (others can be found on VPForum):  
[9] 2020/08/17 23:24:37.352  INFO | Successfully loaded config from C:\Visual Pinball\VPinMAME\DmdDevice.ini. 
 [9] 2020/08/17 23:24:37.466  INFO | No altcolor folder found, ignoring palettes. 
 [9] 2020/08/17 23:24:37.475  INFO | Starting VPinMAME API 1.8.1-SNAPSHOT through VPinballX.exe. 
 [9] 2020/08/17 23:24:37.475  INFO | Assembly located at C:\Visual Pinball\VPinMAME\DmdDevice.dll 
 [9] 2020/08/17 23:24:37.485  INFO | [vpm] Open() 
 [9] 2020/08/17 23:24:37.485  INFO | [vpm] PM_GameSettings(0) 
 [9] 2020/08/17 23:24:37.485  INFO | Disabling game colorization 
 [9] 2020/08/17 23:24:37.500  INFO | Setting game name: potc_600af 
 [9] 2020/08/17 23:24:37.500  INFO | Setting color: #FFFF5820 
 [9] 2020/08/17 23:24:37.517  INFO | Opening virtual display... 
[13] 2020/08/17 23:24:37.578  INFO | Found B2S, moving behind DMD. 
[13] 2020/08/17 23:24:37.594  INFO | Added VirtualDMD renderer. 
[13] 2020/08/17 23:24:37.609  INFO | PinUP DLL starting potc_600af... 
[13] 2020/08/17 23:24:37.609  INFO | Added PinUP renderer. 
[13] 2020/08/17 23:24:37.629  INFO | Transformation options: Resize=Fit, HFlip=False, VFlip=False 
[13] 2020/08/17 23:24:37.629  INFO | Applying default color to render graphs (#FFFF5820). 
[13] 2020/08/17 23:24:37.645  INFO | Resizing virtual DMD to 128x32 
[13] 2020/08/17 23:24:37.656  INFO | Setting up 2-bit VPM Graph for 2 destination(s) 
[13] 2020/08/17 23:24:37.656  INFO | Connecting VPM 2-bit Source to Dmd (Gray2 => Rgb24) 
[13] 2020/08/17 23:24:37.684  INFO | Connecting VPM 2-bit Source to PinUP Writer (Gray2 => Gray2) 
[13] 2020/08/17 23:24:37.689  INFO | Setting up 4-bit VPM Graph for 2 destination(s) 
[13] 2020/08/17 23:24:37.689  INFO | Connecting VPM 4-bit Source to Dmd (Gray4 => Rgb24) 
[13] 2020/08/17 23:24:37.689  INFO | Connecting VPM 4-bit Source to PinUP Writer (Gray4 => Gray4) 
[13] 2020/08/17 23:24:37.704  INFO | Setting up RGB24-bit VPM Graph for 2 destination(s) 
[13] 2020/08/17 23:24:37.704  INFO | Connecting VPM RGB24 Source to Dmd (Rgb24 => Rgb24) 
[13] 2020/08/17 23:24:37.704  INFO | Connecting VPM RGB24 Source to PinUP Writer (Rgb24 => Bitmap) 
[13] 2020/08/17 23:24:37.720  INFO | Setting up Alphanumeric VPM Graph for 2 destination(s) 
[16] 2020/08/17 23:31:58.140 ERROR | System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at LibDmd.Common.ColorUtil.ColorizeFrame(Int32 width, Int32 height, Byte[] frame, Color[] palette, Byte[] colorizedFrame) in D:\Programmes\GitHub\dmd-extensions\LibDmd\Common\ColorUtil.cs:line 257
   at LibDmd.RenderGraph.<>c__DisplayClass55_0.<Connect>b__8(DMDFrame frame) in D:\Programmes\GitHub\dmd-extensions\LibDmd\RenderGraph.cs:line 580
   at System.Reactive.Linq.ObservableImpl.Select`2._.OnNext(TSource value)
--- End of stack trace from previous location where exception was thrown ---
   at System.Reactive.PlatformServices.DefaultExceptionServices.Rethrow(Exception exception)
   at System.Reactive.Stubs.<.cctor>b__1(Exception ex)
   at System.Reactive.AnonymousSafeObserver`1.OnError(Exception error)
   at System.Reactive.ScheduledObserver`1.Dispatch(ICancelable cancel)
   at System.Reactive.Concurrency.Scheduler.<ScheduleLongRunning>b__72(Action`1 a, ICancelable c)
   at System.Reactive.Concurrency.DefaultScheduler.LongRunning.<>c__DisplayClassc`1.<ScheduleLongRunning>b__b(Object arg)
   at System.Reactive.Concurrency.DefaultConcurrencyAbstractionLayer.<>c__DisplayClass5.<StartThread>b__4()
   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadHelper.ThreadStart() 
