### PR TITLE
Drop missed frames instead of trying to catch up

### DIFF
--- a/LibDmd/DmdDevice/DmdDevice.cs
+++ b/LibDmd/DmdDevice/DmdDevice.cs
@@ -595,7 +595,7 @@ namespace LibDmd.DmdDevice
 			_graphs.Dispose();
 			try {
 				_virtualDmd?.Dispatcher.Invoke(() => _virtualDmd.Close());
-
+				_virtualDmd = null;
 			} catch (TaskCanceledException e) {
 				Logger.Warn(e, "Could not hide DMD because task was already canceled.");
 			}

--- a/LibDmd/RenderGraph.cs
+++ b/LibDmd/RenderGraph.cs
@@ -794,7 +794,7 @@ namespace LibDmd
 							AssertCompatibility(source, sourceColoredGray4, dest, destGray4, from, to);
 							Subscribe(sourceColoredGray4.GetColoredGray4Frames()
 									.Select(frame => FrameUtil.Join(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame.Planes))
-									.Select(frame => TransformGray2(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
+									.Select(frame => TransformGray4(source.Dimensions.Value.Width, source.Dimensions.Value.Height, frame, destFixedSize)),
 								destGray4.RenderGray4);
 							break;
 


### PR DESCRIPTION
This PR change the way the frames are dispatched to the destination ; instead of processing each frame the one after the other, it will process only the latest unprocessed frame, dropping any frame that may have been received while processing.

This change is needed to avoid a situation where the pinball controller process frames at a higher rate that the device can process. In this situation, the frames stack up and little by little, the display lags behind the controller. There has been a few post on VPForum on this or issue reports ([latest from Thalamus](https://www.vpforums.org/index.php?showtopic=43569&p=472062) that made me work on this).

I do not have hardware DMD but Thalamus did the testing and report that it improves (see [here](https://github.com/vbousquet/flexdmd/issues/21)). I also performed some testing on virtual DMD/video output and it does not have any side effect (as expected).