### PR TITLE
Add support for dmddevicePUP64.dll

### DIFF
--- a/LibDmd/Output/PinUp/PinUpOutput.cs
+++ b/LibDmd/Output/PinUp/PinUpOutput.cs
@@ -39,7 +39,7 @@ namespace LibDmd.Output.PinUp
 
 			var localPath = new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath;
 			var assemblyFolder = Path.GetDirectoryName(localPath);
-			var dllFileName = Path.Combine(assemblyFolder, "dmddevicePUP.DLL");
+			var dllFileName = Path.Combine(assemblyFolder, Environment.Is64BitProcess ? "dmddevicePUP64.DLL" : "dmddevicePUP.DLL");
 			var pDll = NativeMethods.LoadLibrary(dllFileName);
 
 			if (pDll == IntPtr.Zero) {


### PR DESCRIPTION
This is a tiny PR to use the right pup dll according to the architecture (PuP x64 is not yet released but should be soon).