### PR TITLE
fix: Apply host palette changes to rendergraph.

### DIFF
--- a/LibDmd/DmdDevice/DmdDevice.cs
+++ b/LibDmd/DmdDevice/DmdDevice.cs
@@ -251,8 +251,15 @@ namespace LibDmd.DmdDevice
 		/// <param name="colors">New palette</param>
 		public void SetPalette(Color[] colors)
 		{
-			Logger.Info("Setting palette to {0} colors...", colors.Length);
 			_palette = colors;
+
+			if (!_colorize || _colorizer != null || _palette == null) {
+				return;
+			}
+
+			// if colorization enabled and palette is set, apply palette.
+			Logger.Info($"Applying palette of ${colors.Length} to render graphs.");
+			_graphs.SetPalette(_palette, -1);
 		}
 
 		/// <summary>
@@ -785,18 +792,10 @@ namespace LibDmd.DmdDevice
 
 			// if colorization enabled and frame-by-frame colorization disabled, just set the palette.
 			if (_colorize && _colorizer == null && _palette != null) {
-
 				// if colorization enabled and palette is set, apply palette.
 				Logger.Info("Applying palette to render graphs.");
 				_graphs.ClearColor();
-
-				// todo retrieve palette from .pal
-				// if (_vniColoring != null) {
-				// 	_graphs.SetPalette(_palette, _vniColoring.DefaultPaletteIndex);
-
-				if (_palette != null) {
-					_graphs.SetPalette(_palette, -1);
-				}
+				_graphs.SetPalette(_palette, -1);
 
 			} else {
 				// if colorization disabled, apply default color.

--- a/PinMameDevice/DmdDevice.cs
+++ b/PinMameDevice/DmdDevice.cs
@@ -313,36 +313,17 @@ namespace PinMameDevice
 		private static void InternalSetGray4PaletteDevice(DeviceInstance device, IntPtr palette)
 		{
 			Logger.Info("[dll] Set_16_Colors_Palette({0},...)", device.Id);
-			var size = Marshal.SizeOf(typeof(Rgb24));
 
-			// for some shit reason, using a loop fails compilation.
-			device.DmdDevice.SetPalette(new[] {
-				ConvertColor(GetColorAtPosition(palette, 0, size)),
-				ConvertColor(GetColorAtPosition(palette, 1, size)),
-				ConvertColor(GetColorAtPosition(palette, 2, size)),
-				ConvertColor(GetColorAtPosition(palette, 3, size)),
-				ConvertColor(GetColorAtPosition(palette, 4, size)),
-				ConvertColor(GetColorAtPosition(palette, 5, size)),
-				ConvertColor(GetColorAtPosition(palette, 6, size)),
-				ConvertColor(GetColorAtPosition(palette, 7, size)),
-				ConvertColor(GetColorAtPosition(palette, 8, size)),
-				ConvertColor(GetColorAtPosition(palette, 9, size)),
-				ConvertColor(GetColorAtPosition(palette, 10, size)),
-				ConvertColor(GetColorAtPosition(palette, 11, size)),
-				ConvertColor(GetColorAtPosition(palette, 12, size)),
-				ConvertColor(GetColorAtPosition(palette, 13, size)),
-				ConvertColor(GetColorAtPosition(palette, 14, size)),
-				ConvertColor(GetColorAtPosition(palette, 15, size)),
-			});
+			byte[] p = new byte[48];
+			Color[] colors = new Color[16];
+			Marshal.Copy(palette, p, 0, 48);
+			for (var i = 0; i < 16; i++) {
+				colors[i] = Color.FromRgb(p[i*3], p[i*3+1], p[i*3+2]);
+			}
+			device.DmdDevice.SetPalette(colors);
 		}
 
 		#endregion
-
-		private static Rgb24 GetColorAtPosition(IntPtr data, int pos, int size)
-		{
-			var p = new IntPtr(data.ToInt64() + pos*size);
-			return (Rgb24) Marshal.PtrToStructure(p, typeof (Rgb24));
-		}
 
 		private static Color ConvertColor(Rgb24 color)
 		{


### PR DESCRIPTION
This PR actually applies `Set_4_Colors_Palette_Device()` and `Set_16_Colors_Palette_Device()` to the render graph and not just as an initialization value.

This is so Zen Studios can use this API for their palette changes without having to re-initialize the entire stack, which currently leads to frame stutters.