### PR TITLE
Add automated builds with GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,209 @@
+name: Build and Package
+
+on: [push]
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      matrix:
+        platform: [x86, x64]
+        configuration: [Release]
+    env:
+      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Add dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v2.0.1
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}\.nuget\packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }} #hash of project files
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Download and Setup VPinMAME
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/freezy/dmd-extensions/files/4073824/VPinMAME31_Minimal.zip" -OutFile vpm.zip
+          Expand-Archive vpm.zip -DestinationPath vpm
+          cd vpm
+          regsvr32 /s VPinMAME.dll
+          cd ..
+          dir
+
+      - name: Restore NuGet packages
+        run: nuget restore DmdExtensions.sln
+        
+      - name: Restore DLLExport dependency
+        run: .\DllExport -action Restore -sln-file DmdExtensions.sln
+
+      - name: Update version info
+        shell: pwsh
+        run: |
+          function replaceNumericVersion($name, $fileContent) {
+              $RegularExpression = [regex] "^[^/]*\[assembly:\s*$name\(\""(\d+)\.(\d+)\.(\d+)(\.(\d+))?\""\)"
+              foreach($content in $fileContent)
+              {
+                  $match = [System.Text.RegularExpressions.Regex]::Match($content, $RegularExpression)
+                  if ($match.Success) {
+                      $major=$match.groups[1].value -as [int]
+                      $minor=$match.groups[2].value -as [int]
+                      $patch=$match.groups[3].value -as [int]
+                      $revision=$match.groups[4].value -as [int]
+                      
+                      return $fileContent -replace "^[^/]*\[assembly:\s*$name\(\""[^""]*\""\)", "[assembly: $name(""$major.$minor.$patch.$env:GITHUB_RUN_NUMBER"")"
+                  }
+              }
+          }
+
+          function replaceFullVersion($name, $fileContent) {
+              $RegularExpression = [regex] "[^/]*\[assembly:\s*$name\(\""(\d)\.(\d)\.(\d)(-([\w\W]+))?\""\)"
+              foreach($content in $fileContent)
+              {
+                  $match = [System.Text.RegularExpressions.Regex]::Match($content, $RegularExpression)
+                  if ($match.Success) {
+                      $major=$match.groups[1].value -as [int]
+                      $minor=$match.groups[2].value -as [int]
+                      $patch=$match.groups[3].value -as [int]
+                      $tag=$match.groups[5].value
+
+                      # Get branch name from GitHub context
+                      $branch = if ($env:GITHUB_HEAD_REF) {
+                          $env:GITHUB_HEAD_REF  # For pull requests
+                      } else {
+                          $env:GITHUB_REF_NAME  # For direct pushes
+                      }
+
+                      if ($branch -eq "master") {
+                          if ($tag) {
+                              $version = "$major.$minor.$patch-$tag-r$env:GITHUB_RUN_NUMBER"
+                          } else {
+                              $version = "$major.$minor.$patch-r$env:GITHUB_RUN_NUMBER"
+                          }                
+                      } else {
+                          $version = "$major.$minor.$patch-$($branch.ToUpper())-r$env:GITHUB_RUN_NUMBER"
+                      }            
+
+                      Write-Host "Changing version from $major.$minor.$patch-$tag to $version"
+                      # Set output for other steps to use
+                      "version=$version" >> $env:GITHUB_OUTPUT
+
+                      return $fileContent -replace "^[^/]*\[assembly:\s*$name\(\""[^""]*\""\)", "[assembly: $name(""$version"")"
+                  }
+              }
+          }
+
+          function replaceAny($name, $replaceWith, $fileContent) {
+              $RegularExpression = [regex] "^[^/]*\[assembly:\s*$name\(\""[^""]*\""\)"
+              foreach($content in $fileContent)
+              {
+                  $match = [System.Text.RegularExpressions.Regex]::Match($content, $RegularExpression)
+                  if ($match.Success) {
+                      return $fileContent -replace "^[^/]*\[assembly:\s*$name\(\""[^""]*\""\)", "[assembly: $name(""$replaceWith"")"
+                  }
+              }
+          }
+
+          $assemblyFile = "VersionAssemblyInfo.cs"
+          $fileContent = Get-Content $assemblyFile
+
+          $fileContent = replaceNumericVersion 'AssemblyVersion' $fileContent
+          $fileContent = replaceNumericVersion 'AssemblyFileVersion' $fileContent
+          $fileContent = replaceFullVersion 'AssemblyInformationalVersion' $fileContent
+
+          # Check if this is not a tag build
+          if (-not $env:GITHUB_REF.StartsWith("refs/tags/")) {
+              $fileContent = replaceAny 'AssemblyConfiguration' $env:GITHUB_SHA.Substring(0, 7) $fileContent
+          }
+
+          $fileContent | Set-Content "$assemblyFile"
+          Write-Host "Patching $assemblyFile"
+
+      - name: Build
+        run: msbuild -t:rebuild /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }} DmdExtensions.sln
+      
+      - name: Build installer
+        run: |
+          msbuild /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }} /p:SolutionDir="$env:GITHUB_WORKSPACE\" .\Installer\Installer.wixproj
+          Get-ChildItem -Recurse Installer
+
+      - name: Generate zip bundle
+        shell: pwsh
+        run: |
+          $version = if ($env:GITHUB_REF.StartsWith("refs/tags/")) { $env:GITHUB_REF_NAME } else { $env:GITHUB_SHA.Substring(0, 7) }
+          $zipArchive = "$env:GITHUB_WORKSPACE\Installer\Builds\dmdext-$version-${{ matrix.platform }}.zip"
+          New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\Installer\Builds"
+          
+          Compress-Archive -Path "$env:GITHUB_WORKSPACE\Console\bin\${{ matrix.platform }}\${{ matrix.configuration }}\dmdext.exe" -DestinationPath $zipArchive -Force
+          Compress-Archive -Path "$env:GITHUB_WORKSPACE\Console\bin\${{ matrix.platform }}\${{ matrix.configuration }}\dmdext.log.config" -Update -DestinationPath $zipArchive
+          Compress-Archive -Path "$env:GITHUB_WORKSPACE\Console\ProPinballSlave.bat" -Update -DestinationPath $zipArchive
+
+          $dllSuffix = if ('${{ matrix.platform }}' -eq 'x64') { '64' } else { '' }
+          Compress-Archive -Path "$env:GITHUB_WORKSPACE\PinMameDevice\bin\${{ matrix.platform }}\${{ matrix.configuration }}\DmdDevice$dllSuffix.dll" -Update -DestinationPath $zipArchive
+          Compress-Archive -Path "$env:GITHUB_WORKSPACE\PinMameDevice\bin\${{ matrix.platform }}\${{ matrix.configuration }}\DmdDevice.log.config" -Update -DestinationPath $zipArchive
+          Compress-Archive -Path "$env:GITHUB_WORKSPACE\PinMameDevice\DmdDevice.ini" -Update -DestinationPath $zipArchive
+          
+          Rename-Item "$env:GITHUB_WORKSPACE\PinMameDevice\data" "$env:GITHUB_WORKSPACE\PinMameDevice\dmdext"
+          Compress-Archive -Path "$env:GITHUB_WORKSPACE\PinMameDevice\dmdext" -Update -DestinationPath $zipArchive
+          
+          Rename-Item "$env:GITHUB_WORKSPACE\PinMameDevice\dmdext" "$env:GITHUB_WORKSPACE\PinMameDevice\data"
+
+      - name: Upload ZIP artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dmdext-${{ matrix.platform }}-zip
+          path: ${{ github.workspace }}\Installer\Builds\*.zip
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Upload installer artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dmdext-${{ matrix.platform }}-msi
+          path: ${{ github.workspace }}\Installer\Builds\*.msi
+          retention-days: 90
+          if-no-files-found: error
+
+  create-release:
+    needs: [build-windows]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    steps:
+      - name: Download ZIP artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dmdext-${{ matrix.platform }}-zip
+      - name: Download MSI artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dmdext-${{ matrix.platform }}-msi
+      - name: ls
+        run: ls -alrt
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          generateReleaseNotes: true
+          prerelease: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          allowUpdates: true
+          artifacts: "dmdext*"
+          tag: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || format('v{0}', github.sha) }}
+          name: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'Latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,6 @@ jobs:
           cd vpm
           regsvr32 /s VPinMAME.dll
           cd ..
-          dir
 
       - name: Restore NuGet packages
         run: nuget restore DmdExtensions.sln
@@ -92,7 +91,7 @@ jobs:
                           $env:GITHUB_REF_NAME  # For direct pushes
                       }
 
-                      if ($branch -eq "master") {
+                      if ($branch -eq "master" -or $branch -eq "main") {
                           if ($tag) {
                               $version = "$major.$minor.$patch-$tag-r$env:GITHUB_RUN_NUMBER"
                           } else {
@@ -141,9 +140,7 @@ jobs:
         run: msbuild -t:rebuild /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }} DmdExtensions.sln
       
       - name: Build installer
-        run: |
-          msbuild /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }} /p:SolutionDir="$env:GITHUB_WORKSPACE\" .\Installer\Installer.wixproj
-          Get-ChildItem -Recurse Installer
+        run: msbuild /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }} /p:SolutionDir="$env:GITHUB_WORKSPACE\" .\Installer\Installer.wixproj
 
       - name: Generate zip bundle
         shell: pwsh
@@ -185,8 +182,7 @@ jobs:
   create-release:
     needs: [build-windows]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
-    steps:
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))    steps:
       - name: Download ZIP artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,8 @@ jobs:
   create-release:
     needs: [build-windows]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))    steps:
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+    steps:
       - name: Download ZIP artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
- Add automated build for x86 and x64 with GitHub Actions
- Generate MSI package for both platforms
- Publish a GitHub release when there is a tag from master/main

This PR replaces #493 