### PR TITLE
Add PinballFXClassic as alias for PinballFX3 source type

### DIFF
--- a/Console/Mirror/MirrorOptions.cs
+++ b/Console/Mirror/MirrorOptions.cs
@@ -5,7 +5,7 @@ namespace DmdExt.Mirror
 {
 	class MirrorOptions : BaseOptions
 	{
-		[Option('s', "source", Required = true, HelpText = "The source you want to retrieve DMD data from. One of: [ pinballfx2, pinballfx3, pinballarcade, propinball, screen ].")]
+		[Option('s', "source", Required = true, HelpText = "The source you want to retrieve DMD data from. One of: [ pinballfx2, pinballfx3, pinballfxclassic, pinballarcade, propinball, screen ].")]
 		public SourceType Source { get; set; }
 
 		[Option('f', "fps", HelpText = "How many frames per second should be mirrored. Default: 25")]
@@ -36,8 +36,12 @@ namespace DmdExt.Mirror
 		public IParserState LastParserState { get; set; }
 
 		public new void Validate()
-		{
-			base.Validate();
+			{
+				if (Source == SourceType.PinballFXClassic) {
+					Source = SourceType.PinballFX3;
+				}
+
+				base.Validate();
 
 			if (Source == SourceType.Screen) {
 				if (Position.Length != 4)
@@ -69,6 +73,7 @@ namespace DmdExt.Mirror
 	{
 		PinballFX2,
 		PinballFX3,
+		PinballFXClassic,
 		Screen,
 		PinballArcade,
 		ProPinball,

--- a/LibDmd/Input/PinballFX/PinballFX2Grabber.cs
+++ b/LibDmd/Input/PinballFX/PinballFX2Grabber.cs
@@ -4,9 +4,9 @@
 	{
 		public override string Name { get; } = "Pinball FX2";
 
-		protected override string GetProcessName()
+		protected override System.Collections.Generic.IEnumerable<string> GetProcessNames()
 		{
-			return "Pinball FX2";
+			return new[] { "Pinball FX2" };
 		}
 	}
 }

--- a/LibDmd/Input/PinballFX/PinballFX3Grabber.cs
+++ b/LibDmd/Input/PinballFX/PinballFX3Grabber.cs
@@ -4,9 +4,9 @@
 	{
 		public override string Name { get; } = "Pinball FX3";
 
-		protected override string GetProcessName()
+		protected override System.Collections.Generic.IEnumerable<string> GetProcessNames()
 		{
-			return "Pinball FX3";
+			return new[] { "Pinball FX3", "Pinball FX Classic" };
 		}
 	}
 }

--- a/LibDmd/Input/PinballFX/PinballFX3MemoryGrabber.cs
+++ b/LibDmd/Input/PinballFX/PinballFX3MemoryGrabber.cs
@@ -190,7 +190,7 @@ namespace LibDmd.Input.PinballFX
 
 		protected override IntPtr AttachGameProcess(Process p)
 		{
-			if (p.ProcessName == "Pinball FX3") {
+			if (p.ProcessName == "Pinball FX3" || p.ProcessName == "Pinball FX Classic") {
 				return GetPointerBaseAddress(p);
 			}
 

--- a/LibDmd/Input/PinballFX/PinballFXGrabber.cs
+++ b/LibDmd/Input/PinballFX/PinballFXGrabber.cs
@@ -28,7 +28,7 @@ namespace LibDmd.Input.PinballFX
 	/// </remarks>
 	public abstract class PinballFXGrabber : AbstractSource, IColoredGray2Source
 	{
-		protected abstract string GetProcessName();
+		protected abstract IEnumerable<string> GetProcessNames();
 
 		public IObservable<Unit> OnResume => _onResume;
 		public IObservable<Unit> OnPause => _onPause;
@@ -164,20 +164,22 @@ namespace LibDmd.Input.PinballFX
 
 		private IntPtr FindDmdHandle()
 		{
-			foreach (var proc in Process.GetProcessesByName(GetProcessName())) {
-				var handles = GetRootWindowsOfProcess(proc.Id);
-				foreach (var handle in handles) {
-					NativeCapture.RECT rc;
-					GetWindowRect(handle, out rc);
-					if (rc.Width == 0 || rc.Height == 0) {
-						continue;
+			foreach (var processName in GetProcessNames()) {
+				foreach (var proc in Process.GetProcessesByName(processName)) {
+					var handles = GetRootWindowsOfProcess(proc.Id);
+					foreach (var handle in handles) {
+						NativeCapture.RECT rc;
+						GetWindowRect(handle, out rc);
+						if (rc.Width == 0 || rc.Height == 0) {
+							continue;
+						}
+						var ar = rc.Width / rc.Height;
+						if (ar >= 3 && ar < 4.2) {
+							return handle;
+						}
 					}
-					var ar = rc.Width / rc.Height;
-					if (ar >= 3 && ar < 4.2) {
-						return handle;
-					}
+					Logger.Warn("{0} process found (pid {1}) but DMD not. No game running?", processName, proc.Id);
 				}
-				Logger.Warn("{0} process found (pid {1}) but DMD not. No game running?", GetProcessName(), proc.Id);
 			}
 			return IntPtr.Zero;
 		}

--- a/README.md
+++ b/README.md
@@ -193,15 +193,15 @@ You should see a test image on your DMD as well as on a virtual DMD.
 
 For further tweaking, see options below.
 
-### Pinball FX3
+### Pinball FX3 / Pinball FX Classic
 
-The DMD from Pinball FX3 is pulled directly from the memory.
+The DMD from Pinball FX3 and Pinball FX Classic is pulled directly from the memory.
 
 1. Open a command line prompt ([Windows], type `cmd`, [enter])
-2. Type `dmdext mirror --source=pinballfx3 --no-virtual` [enter]
-3. Start Pinball FX3 and play a game.
+2. Type `dmdext mirror --source=pinballfx3 --no-virtual` [enter] (you can also use `--source=pinballfxclassic`)
+3. Start Pinball FX3 or Pinball FX Classic and play a game.
 
-It doesn't matter whether Pinball FX3 is started before or after `dmdext`, and
+It doesn't matter whether the game is started before or after `dmdext`, and
 it works with or without cabinet mode.
 
 Note that while the current memory grabber code should also work for future


### PR DESCRIPTION
Modified `GetProcessName` to `GetProcessNames` to support multiple process names like` Pinball FX3` or `Pinball FX Classic`.  Command line supports either `-source=pinballfx3` or also `-source=pinballfxclassic`, `pinballfxclassic` is routed back to `pinballfx3`. 