### PR TITLE
Add Pixelcade v2 board support with protocol auto-detection.

### DIFF
--- a/LibDmd/Output/Pixelcade/Pixelcade.cs
+++ b/LibDmd/Output/Pixelcade/Pixelcade.cs
@@ -94,6 +94,7 @@ namespace LibDmd.Output.Pixelcade
 		private byte[] _lastPayload;  // previous payload, for change detection
 		private byte[] _swapBuffer;   // holds the green/blue-swapped payload when ColorMatrix is Rbg
 		private byte _lastCommand;    // previous payload command, for change detection
+		private int _lastPayloadLength = -1; // length of the previous payload, for change detection
 
 		private bool _lastFrameFailed;
 
@@ -235,6 +236,8 @@ namespace LibDmd.Output.Pixelcade
 				} else if (f2 == (byte)'M') {
 					width = 64;
 					height = 32;
+				} else {
+					Logger.Warn("Unrecognized Pixelcade panel size code '{0}' (0x{1:X2}); defaulting to {2}.", (char)f2, f2, new Dimensions(width, height));
 				}
 
 				_isV2 = f3 == (byte)'R';
@@ -256,6 +259,7 @@ namespace LibDmd.Output.Pixelcade
 				_lastPayload = new byte[MaxDataSize];
 				_swapBuffer = new byte[MaxDataSize];
 				_lastCommand = 0; // not a valid frame command, so the first frame always sends
+				_lastPayloadLength = -1;
 			} else {
 				_frameBuffer = new byte[FixedSize.Surface * 3 / 2 + 1];
 				_frameBuffer[0] = RgbLedMatrixFrameCommandByte;
@@ -277,7 +281,7 @@ namespace LibDmd.Output.Pixelcade
 				// v2 boards accept raw RGB888 directly (R,G,B per pixel), no plane splitting.
 				// Honor the color matrix by swapping green/blue for RBG-wired panels.
 				var data = ColorMatrix == ColorMatrix.Rbg ? SwapRgb888GreenBlue(frameRgb24.Data) : frameRgb24.Data;
-				SendV2Frame(Rgb888CommandByte, data);
+				SendV2Frame(Rgb888CommandByte, data, frameRgb24.Data.Length);
 				return;
 			}
 
@@ -304,7 +308,7 @@ namespace LibDmd.Output.Pixelcade
 				// frame.Data is already little-endian RGB565, which is what the v2 firmware expects.
 				// Honor the color matrix by swapping green/blue for RBG-wired panels.
 				var data = ColorMatrix == ColorMatrix.Rbg ? SwapRgb565GreenBlue(frame.Data) : frame.Data;
-				SendV2Frame(Rgb565CommandByte, data);
+				SendV2Frame(Rgb565CommandByte, data, frame.Data.Length);
 				return;
 			}
 
@@ -326,22 +330,34 @@ namespace LibDmd.Output.Pixelcade
 		/// <summary>
 		/// Assembles and sends a v2 payload, skipping frames identical to the last one.
 		/// </summary>
-		private void SendV2Frame(byte command, byte[] data)
+		private void SendV2Frame(byte command, byte[] data, int length)
 		{
-			// FrameUtil.Copy writes data into _lastPayload and reports whether it changed.
-			var changed = FrameUtil.Copy(data, _lastPayload, 0) || command != _lastCommand;
-			_lastCommand = command;
-			if (!changed) {
+			// Skip frames identical to the last one, comparing only the meaningful bytes.
+			// data may be the over-sized _swapBuffer, so we can't rely on data.Length here.
+			if (command == _lastCommand && length == _lastPayloadLength && BuffersEqual(data, _lastPayload, length)) {
 				return;
 			}
+			Buffer.BlockCopy(data, 0, _lastPayload, 0, length);
+			_lastCommand = command;
+			_lastPayloadLength = length;
 
 			var wireLength = _useFraming
-				? BuildFrame(_wireBuffer, command, data, data.Length)
-				: BuildRawCommand(_wireBuffer, command, data, data.Length);
+				? BuildFrame(_wireBuffer, command, data, length)
+				: BuildRawCommand(_wireBuffer, command, data, length);
 
 			if (wireLength > 0) {
 				RenderRaw(_wireBuffer, wireLength);
 			}
+		}
+
+		private static bool BuffersEqual(byte[] a, byte[] b, int length)
+		{
+			for (var i = 0; i < length; i++) {
+				if (a[i] != b[i]) {
+					return false;
+				}
+			}
+			return true;
 		}
 
 		/// <summary>
@@ -456,6 +472,7 @@ namespace LibDmd.Output.Pixelcade
 					_serialPort.Write(_wireBuffer, 0, wireLength);
 				}
 				_lastCommand = 0; // force the next frame to be sent
+				_lastPayloadLength = -1;
 				return;
 			}
 

--- a/LibDmd/Output/Pixelcade/Pixelcade.cs
+++ b/LibDmd/Output/Pixelcade/Pixelcade.cs
@@ -12,6 +12,24 @@ namespace LibDmd.Output.Pixelcade
 	/// <summary>
 	/// Output target for Pixelcade devices.
 	/// </summary>
+	///
+	/// <remarks>
+	/// Supports both the original ("v1") boards as well as the "v2" boards that
+	/// shipped with new firmware. The protocol variant is auto-detected from the
+	/// firmware descriptor returned during the connection handshake:
+	///
+	/// <list type="bullet">
+	///   <item>v1: frame command 0x1F followed by bit-planes (color matrix applied).</item>
+	///   <item>v2, firmware &lt; 23: a raw command (<c>[cmd][data]</c>) carrying raw
+	///         RGB565 (0x30) or RGB888 (0x40), no plane splitting.</item>
+	///   <item>v2, firmware &gt;= 23: the same payloads, but wrapped in a length-prefixed
+	///         frame (<c>0xFE 0xFE | len | cmd | data | 0xAA</c>). A one-time 0xEF init
+	///         command switches the board into this framed mode.</item>
+	/// </list>
+	///
+	/// This mirrors the reference implementation in libdmdutil
+	/// (https://github.com/vpinball/libdmdutil/pull/90).
+	/// </remarks>
 	/// <see cref="http://pixelcade.org/"/>
 	public class Pixelcade : IRgb24Destination, IRgb565Destination, IFixedSizeDestination
 	{
@@ -20,15 +38,29 @@ namespace LibDmd.Output.Pixelcade
 		public bool NeedsDuplicateFrames => false;
 		public bool NeedsIdentificationFrames => false;
 		public int Delay { get; set; } = 100;
-		
-		public Dimensions FixedSize => Dimensions.Standard;
+
+		/// <summary>
+		/// Size of the panel. 128x32 for classic and "X" boards, 64x32 for "M" boards.
+		/// Detected during connection; defaults to standard until then.
+		/// </summary>
+		public Dimensions FixedSize { get; private set; } = Dimensions.Standard;
 
 		public bool DmdAllowHdScaling { get; set; } = true;
 
 		private const int ReadTimeoutMs = 100;
+		private const byte ResponseEstablishConnection = 0x00;
+
+		// v1 / v2-pre-23 command bytes
 		private const byte RgbLedMatrixFrameCommandByte = 0x1F;
 		private const byte RgbLedMatrixEnableCommandByte = 0x1E;
-		private const byte ResponseEstablishConnection = 0x00;
+
+		// v2 command bytes
+		private const byte RgbLedMatrixEnableV23CommandByte = 0x2E; // enable command for v2 boards with framed (>=23) firmware
+		private const byte V23InitCommandByte = 0xEF;               // one-time init that switches v23+ boards into the framed protocol
+		private const byte Rgb565CommandByte = 0x30;
+		private const byte Rgb888CommandByte = 0x40;
+		private const byte FrameStartMarker = 0xFE;
+		private const byte FrameEndDelimiter = 0xAA;
 
 		/// <summary>
 		/// Firmware string read from the device if connected
@@ -42,13 +74,30 @@ namespace LibDmd.Output.Pixelcade
 		public string Port { get; set; }
 
 		/// <summary>
-		/// Color matrix to use, default it RGB.
+		/// Color matrix to use. <see cref="ColorMatrix.Rbg"/> swaps the green and blue
+		/// channels, which most Pixelcade panels require. Applies to both v1 and v2.
 		/// </summary>
 		public ColorMatrix ColorMatrix { get; set; } = ColorMatrix.Rgb;
 
 		private static Pixelcade _instance;
-		private readonly byte[] _frameBuffer;
+
+		// detected protocol state
+		private bool _isV2;
+		private int _firmwareVersion;
+		private bool _useFraming;
+
+		// v1 wire buffer ([cmd][planes...])
+		private byte[] _frameBuffer;
+
+		// v2 scratch buffers (allocated once the size/protocol is known)
+		private byte[] _wireBuffer;   // assembled bytes written to the wire
+		private byte[] _lastPayload;  // previous payload, for change detection
+		private byte[] _swapBuffer;   // holds the green/blue-swapped payload when ColorMatrix is Rbg
+		private byte _lastCommand;    // previous payload command, for change detection
+
 		private bool _lastFrameFailed;
+
+		private int MaxDataSize => FixedSize.Surface * 3;
 
 		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -67,7 +116,7 @@ namespace LibDmd.Output.Pixelcade
 		{
 			if (_instance == null) {
 				_instance = new Pixelcade { Port = port, ColorMatrix = colorMatrix };
-			} 
+			}
 			_instance.Init();
 			return _instance;
 		}
@@ -77,8 +126,6 @@ namespace LibDmd.Output.Pixelcade
 		/// </summary>
 		private Pixelcade()
 		{
-			_frameBuffer = new byte[FixedSize.Surface * 3 / 2 + 1];
-			_frameBuffer[0] = RgbLedMatrixFrameCommandByte;
 		}
 
 		private void Init()
@@ -101,8 +148,10 @@ namespace LibDmd.Output.Pixelcade
 				return;
 			}
 
-			// put the matrix into stream mode 
-			EnableRgbLedMatrix(4, 16);
+			AllocateBuffers();
+
+			// put the matrix into stream mode
+			InitializeMatrix();
 		}
 
 		private bool Connect(string port)
@@ -135,10 +184,15 @@ namespace LibDmd.Output.Pixelcade
 				var hardwareId = Encoding.UTF8.GetString(result.Skip(1+4).Take(8).ToArray());
 				var bootloaderId = Encoding.UTF8.GetString(result.Skip(1+4+8).Take(8).ToArray());
 				Firmware = Encoding.UTF8.GetString(result.Skip(1+4+8+8).Take(8).ToArray());
+
+				// detect protocol variant, version and panel size from the firmware descriptor
+				ParseFirmware(result, 1 + 4 + 8 + 8);
+
 				Logger.Info("Found Pixelcade device on {0}.", port);
 				Logger.Debug(" Hardware ID: {0}", hardwareId);
 				Logger.Debug(" Bootloader ID: {0}", bootloaderId);
 				Logger.Debug(" Firmware: {0}", Firmware);
+				Logger.Info(" Detected: size={0}, v2={1}, firmwareVersion={2}, framed={3}", FixedSize, _isV2, _firmwareVersion, _useFraming);
 				return true;
 
 			} catch (Exception e) {
@@ -150,9 +204,83 @@ namespace LibDmd.Output.Pixelcade
 			}
 			return false;
 		}
-	
+
+		/// <summary>
+		/// Decodes the 8-byte firmware descriptor into protocol/version/size.
+		/// </summary>
+		/// <remarks>
+		/// Layout (see libdmdutil PR #90):
+		/// [0]=='P' marks a descriptor, [2] is the panel size ('X'=128x32, 'M'=64x32),
+		/// [3]=='R' marks a v2 board, and [6][7] are the two-digit firmware version.
+		/// Anything that doesn't match falls back to a classic 128x32 v1 board.
+		/// </remarks>
+		private void ParseFirmware(byte[] response, int offset)
+		{
+			var width = 128;
+			var height = 32;
+			_isV2 = false;
+			_firmwareVersion = 0;
+
+			var f0 = response[offset];
+			var f1 = response[offset + 1];
+			var f2 = response[offset + 2];
+			var f3 = response[offset + 3];
+			var f6 = response[offset + 6];
+			var f7 = response[offset + 7];
+
+			if (f0 == (byte)'P' && f1 != 0 && f2 != 0 && f3 != 0) {
+				if (f2 == (byte)'X') {
+					width = 128;
+					height = 32;
+				} else if (f2 == (byte)'M') {
+					width = 64;
+					height = 32;
+				}
+
+				_isV2 = f3 == (byte)'R';
+
+				if (f6 != 0 && f7 != 0) {
+					_firmwareVersion = (f6 - '0') * 10 + (f7 - '0');
+				}
+			}
+
+			FixedSize = new Dimensions(width, height);
+			_useFraming = _isV2 && _firmwareVersion >= 23;
+		}
+
+		private void AllocateBuffers()
+		{
+			if (_isV2) {
+				// largest payload is RGB888; framed wire adds 6 bytes of overhead
+				_wireBuffer = new byte[MaxDataSize + 6];
+				_lastPayload = new byte[MaxDataSize];
+				_swapBuffer = new byte[MaxDataSize];
+				_lastCommand = 0; // not a valid frame command, so the first frame always sends
+			} else {
+				_frameBuffer = new byte[FixedSize.Surface * 3 / 2 + 1];
+				_frameBuffer[0] = RgbLedMatrixFrameCommandByte;
+			}
+		}
+
+		private void InitializeMatrix()
+		{
+			if (_useFraming) {
+				// one-time command that switches v23+ boards into the framed protocol
+				_serialPort.Write(new[] { V23InitCommandByte }, 0, 1);
+			}
+			EnableRgbLedMatrix(FixedSize.Width / 32, FixedSize.Height);
+		}
+
 		public void RenderRgb24(DmdFrame frameRgb24)
 		{
+			if (_isV2) {
+				// v2 boards accept raw RGB888 directly (R,G,B per pixel), no plane splitting.
+				// Honor the color matrix by swapping green/blue for RBG-wired panels.
+				var data = ColorMatrix == ColorMatrix.Rbg ? SwapRgb888GreenBlue(frameRgb24.Data) : frameRgb24.Data;
+				SendV2Frame(Rgb888CommandByte, data);
+				return;
+			}
+
 			// convert rgb24 to rgb565
 			var frame565 = ColorUtil.ConvertRgb24ToRgb565(FixedSize, frameRgb24.Data, new ushort[FixedSize.Surface]);
 
@@ -172,6 +300,14 @@ namespace LibDmd.Output.Pixelcade
 
 		public void RenderRgb565(DmdFrame frame)
 		{
+			if (_isV2) {
+				// frame.Data is already little-endian RGB565, which is what the v2 firmware expects.
+				// Honor the color matrix by swapping green/blue for RBG-wired panels.
+				var data = ColorMatrix == ColorMatrix.Rbg ? SwapRgb565GreenBlue(frame.Data) : frame.Data;
+				SendV2Frame(Rgb565CommandByte, data);
+				return;
+			}
+
 			var frame565 = FrameUtil.CastToUShort(frame.Data);
 
 			// split into planes to send over the wire
@@ -187,10 +323,113 @@ namespace LibDmd.Output.Pixelcade
 			}
 		}
 
+		/// <summary>
+		/// Assembles and sends a v2 payload, skipping frames identical to the last one.
+		/// </summary>
+		private void SendV2Frame(byte command, byte[] data)
+		{
+			// FrameUtil.Copy writes data into _lastPayload and reports whether it changed.
+			var changed = FrameUtil.Copy(data, _lastPayload, 0) || command != _lastCommand;
+			_lastCommand = command;
+			if (!changed) {
+				return;
+			}
+
+			var wireLength = _useFraming
+				? BuildFrame(_wireBuffer, command, data, data.Length)
+				: BuildRawCommand(_wireBuffer, command, data, data.Length);
+
+			if (wireLength > 0) {
+				RenderRaw(_wireBuffer, wireLength);
+			}
+		}
+
+		/// <summary>
+		/// Swaps the green and blue channels of an RGB888 buffer into <see cref="_swapBuffer"/>.
+		/// Equivalent to <see cref="ColorMatrix.Rbg"/> for the v2 raw path. Never mutates the
+		/// source, which may be shared with other destinations (e.g. the virtual DMD).
+		/// </summary>
+		private byte[] SwapRgb888GreenBlue(byte[] src)
+		{
+			for (var i = 0; i + 2 < src.Length; i += 3) {
+				_swapBuffer[i] = src[i];         // R
+				_swapBuffer[i + 1] = src[i + 2]; // G <- B
+				_swapBuffer[i + 2] = src[i + 1]; // B <- G
+			}
+			return _swapBuffer;
+		}
+
+		/// <summary>
+		/// Swaps the green and blue channels of a little-endian RGB565 buffer into
+		/// <see cref="_swapBuffer"/>, adjusting for the differing channel bit widths.
+		/// </summary>
+		private byte[] SwapRgb565GreenBlue(byte[] src)
+		{
+			for (var i = 0; i + 1 < src.Length; i += 2) {
+				var v = (ushort)(src[i] | (src[i + 1] << 8));
+				var r = (v >> 11) & 0x1F;
+				var g = (v >> 5) & 0x3F;
+				var b = v & 0x1F;
+				var newG = (b << 1) | (b >> 4); // 5-bit blue -> 6-bit green slot
+				var newB = g >> 1;              // 6-bit green -> 5-bit blue slot
+				var swapped = (ushort)((r << 11) | (newG << 5) | newB);
+				_swapBuffer[i] = (byte)(swapped & 0xFF);
+				_swapBuffer[i + 1] = (byte)(swapped >> 8);
+			}
+			return _swapBuffer;
+		}
+
+		/// <summary>
+		/// Builds a length-prefixed frame: <c>0xFE 0xFE | len_lo len_hi | cmd | data | 0xAA</c>.
+		/// </summary>
+		/// <returns>Number of bytes written, or -1 if it doesn't fit.</returns>
+		private int BuildFrame(byte[] buffer, byte command, byte[] data, int dataLength)
+		{
+			var frameSize = 6 + dataLength;
+			if (frameSize > buffer.Length || dataLength > MaxDataSize) {
+				return -1;
+			}
+
+			var payloadLength = (ushort)(1 + dataLength);
+			buffer[0] = FrameStartMarker;
+			buffer[1] = FrameStartMarker;
+			buffer[2] = (byte)(payloadLength & 0xFF);
+			buffer[3] = (byte)((payloadLength >> 8) & 0xFF);
+			buffer[4] = command;
+			if (dataLength > 0) {
+				Buffer.BlockCopy(data, 0, buffer, 5, dataLength);
+			}
+			buffer[5 + dataLength] = FrameEndDelimiter;
+			return frameSize;
+		}
+
+		/// <summary>
+		/// Builds an unframed command: <c>cmd | data</c>.
+		/// </summary>
+		/// <returns>Number of bytes written, or -1 if it doesn't fit.</returns>
+		private int BuildRawCommand(byte[] buffer, byte command, byte[] data, int dataLength)
+		{
+			var commandSize = 1 + dataLength;
+			if (commandSize > buffer.Length || dataLength > MaxDataSize) {
+				return -1;
+			}
+
+			buffer[0] = command;
+			if (dataLength > 0) {
+				Buffer.BlockCopy(data, 0, buffer, 1, dataLength);
+			}
+			return commandSize;
+		}
+
 		public void RenderRaw(byte[] data)
 		{
+			RenderRaw(data, data.Length);
+		}
+
+		public void RenderRaw(byte[] data, int length)
+		{
 			try {
-				_serialPort.Write(data, 0, data.Length);
+				_serialPort.Write(data, 0, length);
 				_lastFrameFailed = false;
 
 			} catch (Exception e) {
@@ -203,12 +442,27 @@ namespace LibDmd.Output.Pixelcade
 
 		public void ClearDisplay()
 		{
+			if (_serialPort == null || !_serialPort.IsOpen) {
+				return;
+			}
+
+			if (_isV2) {
+				// send a black RGB565 frame in the active wire format
+				var blank = new byte[FixedSize.Surface * 2];
+				var wireLength = _useFraming
+					? BuildFrame(_wireBuffer, Rgb565CommandByte, blank, blank.Length)
+					: BuildRawCommand(_wireBuffer, Rgb565CommandByte, blank, blank.Length);
+				if (wireLength > 0) {
+					_serialPort.Write(_wireBuffer, 0, wireLength);
+				}
+				_lastCommand = 0; // force the next frame to be sent
+				return;
+			}
+
 			for (var i = 1; i < _frameBuffer.Length - 1; i++) {
 				_frameBuffer[i] = 0;
 			}
-			if (_serialPort.IsOpen) {
-				_serialPort.Write(_frameBuffer, 0, _frameBuffer.Length);
-			}
+			_serialPort.Write(_frameBuffer, 0, _frameBuffer.Length);
 		}
 
 		public void SetColor(Color color)
@@ -233,17 +487,31 @@ namespace LibDmd.Output.Pixelcade
 
 		public void Dispose()
 		{
-			if (_serialPort.IsOpen) {
+			if (_serialPort != null && _serialPort.IsOpen) {
 				_serialPort.Close();
 			}
 		}
 
 		private void EnableRgbLedMatrix(int shifterLen32, int rows)
 		{
-			_serialPort.Write(new[] {
-				RgbLedMatrixEnableCommandByte, 
-				(byte)(shifterLen32 & 0x0F | ((rows == 8 ? 0 : 1) << 4))
-			}, 0, 2);
+			var configData = (byte)(shifterLen32 & 0x0F | ((rows == 8 ? 0 : 1) << 4));
+
+			if (_isV2) {
+				var command = _useFraming ? RgbLedMatrixEnableV23CommandByte : RgbLedMatrixEnableCommandByte;
+				var buffer = new byte[8];
+				var data = new[] { configData };
+				var length = _useFraming
+					? BuildFrame(buffer, command, data, 1)
+					: BuildRawCommand(buffer, command, data, 1);
+				if (length > 0) {
+					_serialPort.Write(buffer, 0, length);
+				}
+			} else {
+				_serialPort.Write(new[] {
+					RgbLedMatrixEnableCommandByte,
+					configData
+				}, 0, 2);
+			}
 		}
 	}
 }

--- a/PinMameDevice/DmdDevice.ini
+++ b/PinMameDevice/DmdDevice.ini
@@ -297,14 +297,17 @@ delay = 25
 
 [pixelcade]
 
+; v1 and v2 boards are supported; the firmware (and panel size) is auto-detected.
+
 ; if false, doesn't bother looking for a Pixelcade
 enabled = false
 
 ; COM port, e.g. COM3
-port = 
+port =
 
 ; color matrix to use, either "rgb" or "rbg"
-matrix = rgb
+; "rbg" swaps the green and blue channels, which most Pixelcade panels need (applies to v1 and v2)
+matrix = rbg
 
 [networkstream]
 


### PR DESCRIPTION
Detect the protocol variant, firmware version and panel size from the firmware descriptor returned during the connection handshake, mirroring the reference implementation in https://github.com/vpinball/libdmdutil/pull/90.

- v1: unchanged (0x1F frame command with bit-planes)
- v2, firmware < 23: raw [cmd][data] commands carrying RGB565 (0x30) or RGB888 (0x40), no plane splitting
- v2, firmware >= 23: same payloads wrapped in a length-prefixed frame (0xFE 0xFE | len | cmd | data | 0xAA), with a one-time 0xEF init command to switch the board into framed mode

Add green/blue channel swapping for the v2 raw path so the "rbg" color matrix is honored, panel size detection ('X'=128x32, 'M'=64x32), and per-frame change detection to skip identical frames.

Update DmdDevice.ini to document v1/v2 auto-detection and default the matrix to "rbg", which most panels require.

@alinke can you have a look at this, please?